### PR TITLE
docs: add full project review and remediation plan (2026-07-04)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -1,0 +1,272 @@
+# Project Review & Remediation Plan — `cui-test-value-objects`
+
+**Date:** 2026-07-04
+**Scope:** Full review of `src/main`, `src/test`, build/CI configuration, and documentation.
+**Nature of this document:** This is a **plan / review / fix-hints only**. No production code is changed by this document. The actual fixes are to be carried out in follow-up work, partitioned into the pull requests described in section [4](#4-pr-partitioning).
+
+---
+
+## 1. Executive Summary
+
+The project is in good overall health: `./mvnw verify` is **green (264 tests, 0 failures/errors)** on Java 21, all 276 source files carry a uniform Apache-2.0 header, there are **no `@Deprecated` members, no `TODO/FIXME`, no JUnit 4 remnants, and no `Class.newInstance()`** legacy calls. The findings below are therefore improvements on a working baseline, not fixes for a broken build.
+
+That said, the review surfaced a small number of **genuine correctness bugs in the contract-testing logic itself** — the most important category for a *testing library*, because a defective assertion silently passes broken production code in every downstream project that depends on this library. The headline issues:
+
+| # | Severity | Area | One-line |
+|---|----------|------|----------|
+| 1 | **High** | Equals/HashCode contract | `assertNotEquals(null, underTest)` and `assertNotEquals(new Object(), underTest)` never call `underTest.equals(...)` — the null / foreign-type checks are no-ops. |
+| 2 | **High** | Instantiators | `BeanInstantiator.newInstanceFull()` (and `InjectedBeanInstantiator`) populate only *optional* properties, leaving required ones unset. |
+| 3 | **High** | Generators | `InterfaceProxyGenerator` shares one static handler, making all proxies of an interface mutually `equals` → `createCopyWithNonEqualValue()` exhausts its retry guard and fails. |
+| 4 | **High** | MapperTest | `MapperTest` omits the generator `@ExtendWith` extensions that `PropertyAwareTest` declares, so `@PropertyGenerator` / basic-type registration silently never runs. |
+| 5 | **High** | Collection asserts | "Equal ignoring order" compares with two one-way `contains` sweeps → `[a,a,b]` equals `[a,b,b]`. |
+
+Each of the five above was **manually verified in the source** during this review (not merely reported by tooling).
+
+The remaining ~120 findings are medium/low: reflection edge-cases that throw raw `ClassCastException`/NPE instead of descriptive assertions, thread-safety caveats around the global generator registry, a large batch of copy-paste Javadoc errors (wrong `@link` targets, `@see {@link}` misuse, typos), documentation drift in `CLAUDE.md` and the AsciiDoc site, and routine cleanliness/modernization opportunities (redundant `final` on static methods, dead code, Java-21 idioms).
+
+**Total findings:** ~130, grouped into **10 pull requests** ordered by risk and value (correctness first, cosmetics last).
+
+---
+
+## 2. Methodology
+
+- **Build baseline:** `./mvnw -B verify` — exit 0, 264 tests green, no compiler warnings.
+- **Static scan:** grep sweeps for `@Deprecated`, `TODO/FIXME/XXX`, `Class.newInstance`, JUnit 4 imports, license headers, `package-info.java` coverage.
+- **Four parallel deep reviews** covering (a) root + `api` + `junit5`, (b) `contract` + `objects`, (c) `property` + `generator` + `util`, (d) tests + build/CI + docs.
+- **Manual verification** of every High finding and a sample of Mediums against the actual source before inclusion.
+
+**Confidence note:** file/line references are accurate as of commit `772b56c`. Before implementing each item the author should re-open the cited location — a few Medium/Low items (marked *“verify”*) describe latent hazards that current tests don’t exercise, so they need a reproducing test written first to confirm the fix direction.
+
+---
+
+## 3. Findings by Cluster
+
+Findings are listed under the PR that will fix them (section 4 gives the PR ordering/rationale). Severity: **H**igh / **M**edium / **L**ow.
+
+### PR-1 — Object-contract correctness (equals / hashCode / serialization)
+
+Files: `contract/EqualsAndHashcodeContractImpl.java`, `contract/SerializableContractImpl.java`, `junit5/contracts/ShouldBeSerializable.java`, `ShouldImplementToString.java`.
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **H** | `EqualsAndHashcodeContractImpl.java:321` | `assertNotEquals(null, underTest, …)` — JUnit short-circuits `objectsAreEqual(null, x)` to `x == null`; `underTest.equals(null)` is **never called**, so a broken `equals` passes. | Assert `assertFalse(underTest.equals(null), …)`, or swap args so `underTest` is the *unexpected* argument. |
+| **H** | `EqualsAndHashcodeContractImpl.java:326` | `assertNotEquals(new Object(), underTest, …)` invokes `Object.equals` (identity), never `underTest.equals(new Object())`. | Swap argument order / use explicit `assertFalse(underTest.equals(new Object()))`. |
+| **M** | `EqualsAndHashcodeContractImpl.java:343` | `assertBasicContractOnHashCode` fails any object whose `hashCode()` legitimately returns `0` (all-null fields under `Objects.hash`). Valid per `Object#hashCode`. | Drop the `!= 0` check; replace with a consistency check (repeated call returns same value; equal objects → equal hash). |
+| **M** | `EqualsAndHashcodeContractImpl.java:201-247` | `verifyProperties` / `verifyPropertiesInReverse` are ~40 lines of duplicated logic differing only in iteration direction. | Extract one method taking a (possibly reversed) property list. |
+| **L** | `EqualsAndHashcodeContractImpl.java:175` | `upperBound = min(…, …) - 2` is opaque and can go negative. | Clamp `>= 0`; extract a named helper/constant explaining the `-2`. |
+| **L** | `EqualsAndHashcodeContractImpl.java:271` | Reverse iteration via `String[]` + manual index. | Use `reversed()` on a `SequencedCollection` (Java 21). |
+| **M** | `ShouldBeSerializable.java:44` | Failure message dereferences `getUnderTest()` eagerly → opaque NPE instead of assertion failure when null. | Use the `Supplier<String>` overload / `assertNotNull(underTest)` first. |
+| **L** | `ShouldImplementToString.java:42` | Same null hazard on `underTest.getClass()`. | Lead with `assertNotNull(underTest, …)`. |
+| **M** | `SerializableContractImpl.java:129,147` | `AssertionError` thrown without the caught exception as cause → lost stack trace. | `new AssertionError(msg, e)`. |
+
+### PR-2 — Instantiator & object-creation correctness
+
+Files: `objects/impl/BeanInstantiator.java`, `InjectedBeanInstantiator.java`, `FactoryBasedInstantiator.java`, `ConstructorBasedInstantiator.java`, `BuilderConstructorBasedInstantiator.java`, `BuilderFactoryBasedInstantiator.java`, `contract/ObjectCreatorContractImpl.java`, `contract/BuilderContractImpl.java`, `contract/CopyConstructorContractImpl.java`.
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **H** | `BeanInstantiator.java:81` | `newInstanceFull()` applies only `getAdditionalProperties()` (non-required), violating "all attributes set" — required props left unset for `anyValueObject()`. Verified: `getAllProperties()` exists. | Use `getWritableProperties()` / `getAllProperties()` (as `BuilderParameterizedInstantiator` does). |
+| **M** | `InjectedBeanInstantiator.java:71` | Same bug: `newInstanceFull()` omits required properties. | Apply all writable properties. |
+| **M** | `FactoryBasedInstantiator.java:94` | `factoryMethod.invoke(null, …)` throws raw NPE if the configured method is non-`static`; never validated. | Assert `Modifier.isStatic(...)` in the constructor with a diagnostic. |
+| **M** | `BuilderConstructorBasedInstantiator.java:82` (also `BuilderFactoryBasedInstantiator.java:89,99`, `FactoryBasedInstantiator.java:73-75`) | `getDeclaredMethod` misses `build()`/factory methods inherited from an abstract superclass. | Fall back to `getMethod(...)` or walk the hierarchy. |
+| **M** | `ObjectCreatorContractImpl.java:80` (also `BuilderContractImpl.java:109`) | Bare `catch (AssertionError)` treats *any* assertion failure as "constructor correctly rejected missing required attr", masking real bugs. | Signal rejection with a dedicated exception type, or verify the message/cause. |
+| **M** | `ConstructorBasedInstantiator.java:79` (also `FactoryBasedInstantiator.java:86`) | `AssertionError` thrown without cause → lost trace. | `new AssertionError(msg, e)`. |
+| **M** | `FactoryBasedInstantiator.java:84` | Message says "Unable to find a constructor" for a *factory-method* lookup; omits method name + enclosing type. | Report `factory method '<name>' on <type> …`. |
+| **L** | `ConstructorBasedInstantiator.java:89` (also `FactoryBasedInstantiator.java:96`) | Concatenation yields stray `" , due to"`; factory path wrongly says "constructor". | Fix concatenation + member name. |
+| **L** | `BuilderFactoryBasedInstantiator.java:115` | Failure message reports `targetClass` as owner of a factory method that lives on the enclosing type. | Keep `enclosingType` in a field; use it in the message. |
+| **L** | `CopyConstructorContractImpl.java:104` | `LOGGER.info("… {}" + verifyDeepCopyIgnore)` — concatenation instead of placeholder → garbled output. | Pass as format argument. |
+| **L** | `CopyConstructorContractImpl.java:173` | JUnit `assertFalse` used for argument validation (`existingContracts` emptiness). | Use `checkArgument`/`IllegalArgumentException`. |
+| **L** | `ObjectCreatorContractImpl.java:152` | `annotated` not null-checked unlike sibling factories. | Add `requireNonNull(annotated, …)`. |
+| **M** | `BuilderContractImpl.java:105-116` | `failed` flag is inverted (`failed = true` on success); idiom duplicated in `ObjectCreatorContractImpl.java:76-85`. | Rename `builderAccepted`; share the "must fail without required prop" logic. |
+| **L** | `ConstructorBasedInstantiator.java:68` | `requireNonNull(constructor,…)` dead (`getConstructor` never returns null); ditto `FactoryBasedInstantiator.java:77-80`, `ReflectionUtil.java:110`. | Delete unreachable null checks. |
+| **L** | `AbstractOrderedArgsInstantiator.java:88-89` | Dead branch: `if (null != support.getGeneratedValue()) { /* empty */ }` — value always null here. | Remove dead branch. |
+| **L** | `AbstractInlineInstantiator.java:38` | `PROPERTIES_MUST_NOT_BE_NULL` declared here but unused by this class; three unrelated classes static-import it. | Move constant to a shared holder. |
+| **L** | `InjectedBeanInstantiator.java:46-48` | `objectProvider`/`callbackHandler` lack `@NonNull` (unlike `runtimeProperties`) → late NPE. | Annotate `@NonNull`. |
+| **L** | `BuilderParameterizedInstantiator.java:79` | `toString()` concatenates without separator → run-together diagnostics. | Insert newline/label. |
+
+### PR-3 — Generator subsystem correctness
+
+Files: `generator/dynamic/impl/InterfaceProxyGenerator.java`, `ConstructorBasedGenerator.java`, `DynamicProxyGenerator.java`, `ArraysGenerator.java`, `generator/TypedGeneratorRegistry.java`, `generator/dynamic/GeneratorResolver.java`.
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **H** | `InterfaceProxyGenerator.java:36` | One shared static `DEFAULT_HANDLER`; `DefaultInvocationHandler` compares proxy handlers by identity, so **all** proxies of an interface are mutually `equals`/share `hashCode` → `PropertySupport.createCopyWithNonEqualValue()` exhausts its 50-try guard → `AssertionError`. Verified. | Instantiate a fresh `DefaultInvocationHandler` per `next()`. |
+| **M** | `TypedGeneratorRegistry.java:63-66` | Check-then-act (`containsKey` then `get`) on shared `ConcurrentHashMap` is non-atomic → `Optional.of(null)` NPE under concurrent `clear`/`remove`. | `Optional.ofNullable((TypedGenerator<T>) REGISTRY.get(type))`. |
+| **M** | `ConstructorBasedGenerator.java:201-215` | Cycle protection only covers same-type params; mutually recursive types (A↔B) → `StackOverflowError`. | Track in-progress types (ThreadLocal) in `GeneratorResolver`; fail cleanly / return `DummyGenerator` on re-entry. |
+| **L** | `ConstructorBasedGenerator.java:190-196` | Last-resort loop returns first non-copy constructor even when `createForConstructor` returns `Optional.empty()`. | Continue the loop on empty. |
+| **L** | `ConstructorBasedGenerator.java:100` | `logUsedValuesForConstructor` calls `object.getClass()` on each param → NPE when a generator yields `null`. | `String.valueOf(object)` / null-guard. |
+| **L** | `DynamicProxyGenerator.java:71-74` | No guard for `final` (unproxyable) classes → raw javassist `RuntimeException` instead of `Optional.empty()`. | Return empty when `Modifier.isFinal(...)`; catch javassist failures. |
+| **L** | `DynamicProxyGenerator.java:72` | `setFilter(m -> "equals".equals(...))` is dead — no `MethodHandler` is ever installed. | Remove filter or install the intended handler. |
+| **M** | `ArraysGenerator.java:64` | `@param` says "must **not** be an array type" — inverse of the real contract. | Reword to "must be an array type". |
+| **L** | `GeneratorResolver.java:117` | Malformed `@return` "if applicable or or `not Optional.isPresent()`". | Rewrite as "… or `Optional#empty()` otherwise". |
+
+### PR-4 — Property, reflection & collection-assert correctness
+
+Files: `property/util/PropertyAccessStrategy.java`, `property/util/CollectionAsserts.java`, `property/PropertySupport.java`, `property/impl/PropertyMetadataImpl.java`, `util/ReflectionHelper.java`, `util/DeepCopyTestHelper.java`.
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **H** | `CollectionAsserts.java:61-80` | "Equal ignoring order" compares with two one-way `contains` sweeps → `[a,a,b]` equals `[a,b,b]`. Verified as design flaw. | Compare frequency maps (`Collections.frequency` / `Map<Object,Long>`). |
+| **M** | `CollectionAsserts.java:54` | Guard checks `instanceof Iterable` but line 62 casts to `Collection` → raw `ClassCastException` for non-`Collection` `Iterable`. | Guard on `instanceof Collection` (or convert to list first). |
+| **M** | `PropertyAccessStrategy.java:54,68` | Copy-paste: `assertNotNull(target, …)` twice; `propertyMetadata` never null-checked → unexplained NPE. | Second assertion should target `propertyMetadata`. |
+| **M** | `PropertySupport.java:145` | `assertValueSet` uses `assertEquals` — for array-typed properties this is reference equality, so defensive-copy getters fail. | Branch on array type → `assertArrayEquals`/`Arrays.deepEquals`. |
+| **M** | `ReflectionHelper.java:193` | Raw (non-generic) collection field → `field.getGenericType()` is a `Class`; unguarded `(ParameterizedType)` cast → `ClassCastException` instead of the descriptive `IllegalStateException`. | Check `instanceof ParameterizedType` first. |
+| **M** | `PropertyMetadataImpl.java:274-276` | `compareTo` orders by name only; Lombok `equals` compares all fields; metadata collected into `TreeSet` → differently-configured same-name metadata silently collapse (`compareTo==0` disagrees with `equals`). | Make ordering-vs-equality consistent (name-based `equals`, or document intentional natural ordering). |
+| **L** | `DeepCopyTestHelper.java:135` | `checkForList` blind-casts `resultCopy` to `List` + indexes by source size → `ClassCastException`/`IndexOutOfBounds` instead of clean assertion. | Assert `instanceof List` + equal size first. |
+| **L** | `DeepCopyTestHelper.java:90` | `resultSource.getClass().isPrimitive()` always false (reflection returns boxed) → dead "skip primitives" branch. | Test wrapper types or drop the branch. |
+| **L** | `DeepCopyTestHelper.java:106` | Missing space: `getName() + "failed: "` → "getFoofailed:". | `" failed: "`. |
+| **L** | `CollectionAsserts.java:41-42` | Empty `@param expected`/`@param actual` on public API. | Add descriptions. |
+| **L** | `PropertySupport.java:155,167` | `@return he read Property` typo; `writeProperty`'s `@return` wrongly describes a read result. | Correct both. |
+
+### PR-5 — MapperTest correctness & API
+
+File: `MapperTest.java` (+ `PropertyAwareTest.java` for one related item).
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **H** | `MapperTest.java:83` | Implements `GeneratorRegistry` but declares **no** `@ExtendWith` (unlike `PropertyAwareTest:59`) → `@PropertyGenerator`/`registerBasicTypes()` silently never run; the project's own mapper test hand-wires `GeneratorAnnotationHelper` in `@BeforeEach` to compensate. Verified. | Add `@ExtendWith({GeneratorControllerExtension.class, GeneratorRegistryController.class})`. |
+| **M** | `MapperTest.java:185` | Target scanning gated on class-level `@PropertyReflectionConfig` (documented for the *source*) → `skip=true` for the source empties the *target* metadata. | Gate on the `config` param of `verifyMapper(...)`. |
+| **M** | `MapperTest.java:187` | Target props scanned from `anyTargetObject().getClass()` (runtime class, maybe proxy/subclass) though `targetClass` is already resolved; full object generated just for its class. | Scan `targetClass` directly. |
+| **M** | `MapperTest.java:100` | Misspelled protected API `intializeTypeInformation()` leaks to subclasses (own tests call it). | Add correctly-spelled `initializeTypeInformation()` delegate; deprecate the misspelled one. |
+| **L** | `MapperTest.java:108,113,116` | `assertNotNull` after `orElseThrow` — dead code. | Delete the three assertions. |
+| **L** | `MapperTest.java:103,107,112,115` | Inconsistent exception types (`IllegalArgumentException` vs `AssertionError`); messages lack a space before the class. | Pick one exception type; fix spacing. |
+| **L** | `MapperTest.java:41,44,46` | Wildcard imports diverge from explicit-import style everywhere else. | Expand to explicit imports. |
+| **L** | `PropertyAwareTest.java:63` | Lombok `@Setter setTargetBeanClass()` is overwritten by `@BeforeEach` and can desync from resolved metadata. | Drop or restrict to `PROTECTED` with docs. |
+
+### PR-6 — Production Javadoc corrections
+
+Pure Javadoc; no behavioral change. Fixes wrong `@link` targets, `@see {@link}` misuse, and typos flagged by doclint.
+
+| Sev | Location | Problem |
+|-----|----------|---------|
+| **H** | `api/contracts/VerifyCopyConstructor.java:63` | Doc says `verifyDeepCopy()` "defaults to `true`" but actual default is `false` — actively misleading. |
+| **M** | `api/property/PropertyConfig.java:49,61,68,76,83,90,100,107,116` | Nine `@see {@link …}` — `@see` must take a bare reference. |
+| **M** | `api/object/VetoType.java:25` | Invalid inline tag `{@PortalNavigationMenuItemPackageTest}`; `value()` doc contradicts exclusion semantics. |
+| **M** | `api/generator/PropertyGeneratorHints.java:25,34` | Docs reference `PropertyGenerator` but the container holds `PropertyGeneratorHint[]`. |
+| **M** | `api/contracts/VerifyFactoryMethods.java:33` | `value()` doc says "array of `VerifyConstructor`" but returns `VerifyFactoryMethod[]`. |
+| **M** | `api/object/VerifyObjectTestContract.java:22` | Links `ObjectTestConfig` where `ObjectTestContracts` is meant. |
+| **M** | `junit5/contracts/ShouldImplementToString.java:26,36-37` | Copy-pasted from equals/hashCode contract; claims to verify `equals`/`hashCode`. |
+| **M** | `contract/CopyConstructorContractImpl.java:46-48` | Class Javadoc copy-pasted from `ObjectCreatorContractImpl`; no mention of copy-constructor testing. |
+| **M** | `contract/BeanPropertyContractImpl.java:108-119` | Doc says annotate with `BeanPropertyContractImpl`; correct annotation is `@VerifyBeanProperty`. |
+| **M** | `contract/BuilderContractImpl.java:140` | `@return` says `BeanPropertyContractImpl`, returns `Optional<BuilderContractImpl<T>>`. |
+| **M** | `objects/RuntimeProperties.java:148,179,211,242,273` | Docs say "mutable `List`" but return unmodifiable `Stream.toList()`. |
+| **M** | `ValueObjectTest.java:61`, `PropertyAwareTest.java:50` | Point to `de.cuioss.test.valueobjects.junit5` which has no `package-info.java`. |
+| **L** | `util/AnnotationHelper.java:180,229,287` | `@return` promises `SortedSet`, returns `List`. |
+| **L** | `util/AnnotationHelper.java:226-227` | Doc says `@VerifyBeanProperty`, code requires `@VerifyBuilder`. |
+| **L** | `util/GeneratorAnnotationHelper.java:46,58-59,129` | Empty Javadoc constant; "must not null"; wrong `@return` type (`VerifyConstructor` vs `PropertyGeneratorHint`). |
+| **L** | `util/ReflectionHelper.java:59,92,216` | Docs say "immutable List" for a mutable `ArrayList`; "ususally" typo. |
+| **L** | `contract/ReflectionUtil.java:42,66-67` | "msut" typo; `assertToStringMethodIsOverriden` doc says `hashCode()`. |
+| **L** | `generator/JavaTypesGenerator.java:52 (+~30)` | Repeated "of of" and "an instance of of" typos. |
+| **L** | `contract/ToStringContractImpl.java:27-28`, `MapperContractImpl.java:69`, `MapperAttributesAsserts.java:119`, `EqualsAndHashcodeContractImpl.java:60` | Typos: "will fully populated", "mimimal", "ist this intentional", "hasCode()". |
+| **L** | `api/contracts/VerifyConstructor.java:56`, `VerifyFactoryMethod.java:68` | Dangling "…isRequired()}. it is used". |
+| **L** | `api/contracts/VerifyBuilder.java:158`, `api/property/PropertyBuilderConfig.java:59` | "withPropertName()" typo. |
+| **L** | `api/object/ObjectTestContracts.java:54` | "and than actually serializing" → "then". |
+| **L** | Various empty `@param`/`@return` tags | `ValueObjectTest.java:70,104,137`; `PropertyAwareTest.java:83`; `contract/ContractRegistry.java:41`; `objects/RuntimeProperties.java:97`; `objects/ObjectInstantiator.java:25`; `AbstractOrderedArgsInstantiator.java:37`; `BuilderInstantiator.java:46`; `objects/impl/ExceptionHelper.java:33-34`; `DeepCopyTestHelper.java:32` (missing class doc). |
+
+*Recommendation:* enable doclint (`-Xdoclint:all,-missing` at minimum) in the Javadoc build after this PR to prevent regressions.
+
+### PR-7 — Project documentation (CLAUDE.md, README, AsciiDoc)
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **H** | `CLAUDE.md:122` | Claims parent POM `cui-java-parent:1.3.3`; `pom.xml:7` declares `1.4.5`. | Correct, or say "see pom.xml parent". |
+| **M** | `CLAUDE.md:151-157` | CI section describes three in-repo jobs + Java 21/25 matrix + Temurin; `maven.yml` actually delegates to `cuioss/cuioss-organization` reusable workflow v0.6.8. | Rewrite to describe the reusable-workflow setup driven by `.github/project.yml`. |
+| **M** | `CLAUDE.md:33-41` vs `165-179` | Two contradictory Git Workflow sections (auto-merge enabled vs "do NOT enable auto-merge"). | Delete the older section; keep the Gemini-review workflow. |
+| **M** | `CLAUDE.md:25` | "`-Dmaven.compiler.release=<version>`" has no effect; parent reads `${maven.compiler-plugin.release}`. | Document `-Dmaven.compiler-plugin.release=<version>`. |
+| **M** | `src/site/asciidoc/testing-value-objects.adoc` | `@VerifyCopyConstructor` and `@VerifyObjectTestContract` are implemented + tested but documented nowhere. | Add sections for both. |
+| **L** | `src/site/asciidoc/managing-metadata.adoc:14-20` | Sample output shows pre-rename `io.cui.*` packages + `QuickCheckGeneratorAdapter`. | Regenerate from a current run. |
+| **L** | `src/site/asciidoc/reflection-system.adoc:5` | References `cui-java-util`; actual artifact is `cui-java-tools`. | Correct the name. |
+| **L** | `src/site/asciidoc/testing-value-objects.adoc:119` | German-locale "Okt 14, 2020" stale sample output. | Refresh. |
+
+### PR-8 — Build & CI hygiene
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **M** | `pom.xml:33` | `<maven.compiler.release>21</…>` is dead — parent uses `${maven.compiler-plugin.release}`; the property is never read and can harm multi-version CI overrides. | Remove it (override via `maven.compiler-plugin.release` if needed). |
+| **M** | `.mvn/wrapper/maven-wrapper.properties:19` | No `distributionSha256Sum`/`wrapperSha256Sum` → wrapper download unverified. | Add checksum(s) for pinned Maven 3.9.6. |
+| **L** | `.mvn/wrapper/maven-wrapper.properties:19` | Maven 3.9.6 (Jan 2024) behind current 3.9.x. | Bump `distributionUrl`. |
+| **L** | `pom.xml:38-47,70` | `<scope>compile</scope>` inside `<dependencyManagement>` for javassist is redundant/discouraged; javassist not in the parent BOM. | Drop the dependencyManagement block; set version directly on the dependency. |
+| **L** | `pom.xml:35` | `<version.cui.test.generator>3.0.2</…>` duplicates `cui-java-bom:1.4.5` — pins stale on parent upgrade. | Delete; inherit BOM version. |
+| **L** | `.github/dependabot.yml:8` | Only `maven` ecosystem; SHA-pinned reusable workflows have no `github-actions` update coverage in-repo. | Add `github-actions` ecosystem (unless org tooling owns it). |
+| **L** | `lombok.config:2` | No trailing newline. | Add final newline. |
+
+### PR-9 — Code cleanliness & Java-21 modernization (main sources)
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **L** | Many | Redundant `final` on `static` methods: `BeanPropertyContractImpl:124`, `BuilderContractImpl:144`, `CopyConstructorContractImpl:158`, `ObjectCreatorContractImpl:149`, `RuntimeProperties:301`, `SerializableContractImpl:110,122,141`, `CollectionType:187`, `ArraysGenerator:68`, `DynamicProxyGenerator:66`, `InterfaceProxyGenerator:58`, `ConstructorBasedGenerator:120`, `PropertyHelper:114,142,156,173,207`. | Drop `final`. |
+| **L** | `util/IdentityResourceBundle.java:39` | `new Vector<>().elements()` for an empty enumeration. | `Collections.emptyEnumeration()`; drop `Vector` import. |
+| **L** | `property/impl/PropertyMetadataImpl.java:84-93` | Classic `switch` + `default` over `CollectionType` swallows exhaustiveness. | Arrow-form exhaustive `switch` expression (Java 21); drop `default`. |
+| **L** | `util/AnnotationHelper.java:378-382`, `AbstractOrderedArgsInstantiator.java:63-72` | Pre-sized `toArray(new T[size])` / hand-rolled array copy. | `toArray(new T[0])` / `toArray(T[]::new)`. |
+| **L** | `api/property/PropertyConfig.java:70` | Raw `Class<? extends TypedGenerator>` + `@SuppressWarnings("rawtypes")` where generic form compiles (cf. `PropertyGenerator.value()`). | Use `Class<? extends TypedGenerator<?>>`; drop suppression. |
+| **L** | `util/WildcardDecoratorGenerator.java:22` | Raw `TypedGenerator` + `@SuppressWarnings("rawtypes")` where `TypedGenerator<Object>` compiles. | Implement `TypedGenerator<Object>`. |
+| **L** | `api/object/ObjectTestContracts.java:64` | Reflective `DefaultInstantiator` per call for known stateless impls. | Store a `Supplier<ObjectTestContract>` (constructor ref). |
+| **M** | `util/AnnotationHelper.java:64-134` | `constructorConfigToPropertyMetadata` / `factoryConfigToPropertyMetadata` are line-for-line duplicates. | Extract a shared private method. |
+| **L** | `util/AnnotationHelper.java:76-80,127-131` | `modifyPropertyMetadata` re-invoked per `config.of()` entry; one call suffices. | Move out of the loop. |
+| **L** | `util/AnnotationHelper.java:50` + `util/GeneratorAnnotationHelper.java:47` | Duplicated `UNABLE_TO_INSTANTIATE_GENERATOR` constants, referenced nowhere. | Delete (public one is API-breaking → deprecate first). |
+| **L** | `util/AnnotationHelper.java:373-383` | `List`-based `modifyPropertyMetadata` overload has no production caller. | Remove or deprecate. |
+| **L** | `generator/JavaTypesGenerator.java:49,277` | Instances self-register into static mutable list from constructor. | Build an explicit `List.of(...)`. |
+| **L** | `generator/dynamic/GeneratorResolver.java:60-92`, `generator/TypedGeneratorRegistry.java`, `junit5/extension/GeneratorRegistryController.java:42` | Global static registry + `clear()` + resolution side effects make the generator system hostile to JUnit parallel execution. | Document the single-threaded constraint or scope the registry per test context (`ExtensionContext.Store` / `InheritableThreadLocal`). |
+| **L** | `util/PropertyHelper.java:43-46,53-80` | `@SuppressWarnings("squid:S1118")` + private ctor instead of `@UtilityClass`; racy non-volatile "log once" flags. | Use `@UtilityClass`; use `AtomicBoolean.compareAndSet`. |
+| **L** | `util/DeepCopyTestHelper.java:113,129` | Mixed `static`/non-static in an `@UtilityClass`. | Make consistent. |
+| **L** | `contract/support/MapperAttributesAsserts.java:37,115-136` | Pointless `@EqualsAndHashCode` on a stateful helper; asserts collected into `HashMap` → nondeterministic failure order. | Drop annotation; use `LinkedHashMap`/`TreeMap`. |
+| **L** | `objects/RuntimeProperties.java:301-308` | `extractNames` returns immutable empty set but mutable `HashSet` otherwise; caller `removeAll`s it (works by accident). | Always return a mutable `HashSet`. |
+| **L** | `contract/support/MappingAssertStrategy.java:57,83,85`, `MapperAttributesAsserts.java:92-93` | Assertion messages lack separators before appended metadata. | Add `": "`. |
+| **L** | `ValueObjectTest.java:96` | Manual `forEach`-and-add into mutable `ArrayList` exposed via getter. | `…stream().map(TestContract::getInstantiator).toList()`. |
+| **L** | `junit5/extension/GeneratorRegistryController.java:48` | Debug message has stray literal `{ }` braces. | Match plain-concatenation style. |
+| **M** | Missing `package-info.java` | 12 of 21 main packages lack it (incl. public-facing `util`, `property`, `junit5`, `junit5/contracts`, `generator`, `objects/impl`), while CLAUDE.md advertises "extensive examples" there. | Add `package-info.java` to remaining public packages. |
+
+### PR-10 — Test-suite improvements
+
+| Sev | Location | Problem | Fix hint |
+|-----|----------|---------|----------|
+| **M** | Coverage gaps | No direct tests for `contract/ContractRegistry`, `contract/support/MapperAttributesAsserts`, `objects/impl/ExceptionHelper`, `generator/dynamic/impl/DefaultInvocationHandler`, `generator/impl/DummyGenerator`, `util/WildcardDecoratorGenerator`. | Add focused unit tests (prioritize `WildcardDecoratorGenerator` + `ExceptionHelper` error paths). Also add regression tests reproducing the PR-1…PR-5 bugs. |
+| **L** | `testbeans/ComplexBean.java` | Duplicated byte-for-byte in `junit5/testbeans/` and `mapper/support/`. | Consolidate to one shared support package. |
+| **L** | `contract/MockTestContract.java` | Identical duplicate in `junit5/testbeans/`. | Consolidate. |
+| **L** | `junit5/ValueObjectTestCopyConstructorTest.java:25` (+ `…FactoryTest`, `…ConstructorTest`) | `public class` while 57 other test classes are package-private. | Drop `public`. |
+
+---
+
+## 4. PR Partitioning
+
+The findings are split into **10 PRs**, ordered so that **behavioral correctness lands first** (highest value, needs the most review scrutiny and regression tests) and **cosmetic/mechanical changes land last** (low risk, easy to review in bulk). Each PR is independently mergeable; the only soft dependency is that PR-10's regression tests should follow the correctness PRs they cover.
+
+| PR | Title | Findings | Risk | Rationale for grouping |
+|----|-------|----------|------|------------------------|
+| **1** | Object-contract correctness | 9 | High-impact, low-churn | The library's core assertions; each needs a regression test proving the old code passed a broken object. |
+| **2** | Instantiator & object-creation correctness | 18 | Medium | All touch the `objects.impl` instantiators + creator contracts; cohesive review surface. |
+| **3** | Generator subsystem correctness | 9 | Medium | Isolated to `generator/**`; the proxy-equality bug (H) needs its own repro. |
+| **4** | Property/reflection/collection-assert correctness | 11 | Medium | Cross-cuts `property/**` + `util` reflection helpers; shared "descriptive error not raw exception" theme. |
+| **5** | MapperTest correctness & API | 8 | Medium | Single class; the missing-extension bug changes behavior for all mapper tests → deserves focused review + a test that fails without it. |
+| **6** | Production Javadoc corrections | ~35 | Very low | Pure Javadoc; large but mechanical; enable doclint at the end. |
+| **7** | Project documentation | 8 | Very low | `CLAUDE.md` + README + AsciiDoc; no code. |
+| **8** | Build & CI hygiene | 7 | Low | `pom.xml` + wrapper + lombok + dependabot; verify `./mvnw verify` still green + reproducible. |
+| **9** | Code cleanliness & Java-21 modernization | ~24 | Low | Main-source non-behavioral cleanups + `package-info.java`; large but low-risk, reviewable as a sweep. |
+| **10** | Test-suite improvements | 4 groups | Low | Test-only: coverage gaps + dedup + conventions; includes regression tests for PR-1…5. |
+
+**Sequencing recommendation**
+
+1. Land **PR-1 → PR-5** first (correctness), each with a regression test in the same PR (or immediately after via PR-10).
+2. **PR-6 / PR-7 / PR-8** can proceed in parallel at any time — zero behavioral overlap.
+3. **PR-9** last among code PRs, to avoid churn conflicts with the correctness PRs touching the same files (e.g. redundant-`final` removal overlaps files edited in PR-1/2/3).
+4. **PR-10** regression tests should reference the fixes from PR-1…5; if a correctness PR ships without its test, add it here.
+
+**Per-PR checklist (apply to every PR)**
+
+- [ ] `./mvnw clean verify` green (Java 21; ideally also 25).
+- [ ] For correctness PRs: a new test that **fails on `main`** and passes with the fix.
+- [ ] No new doclint warnings introduced (PR-6 turns doclint on).
+- [ ] Conventional-commit message; follow the repo Git Workflow (feature branch → PR → CI + Gemini review → address every comment → merge on approval).
+
+---
+
+## 5. Notes & Caveats for the Implementer
+
+- **Verify-before-fix items:** the concurrency findings (`TypedGeneratorRegistry`, `GeneratorRegistryController.clear()`, `PropertyHelper` log-once flags) are latent — the current suite runs single-threaded, so they don't manifest today. Decide deliberately between *"document single-threaded constraint"* and *"make thread-safe"*; the former is cheaper and matches how the library is used.
+- **API-breaking items** are flagged inline (`intializeTypeInformation` rename, deleting the `public` `UNABLE_TO_INSTANTIATE_GENERATOR` constant, `PropertyConfig.generator()` return-type change). Prefer *deprecate-then-remove* across a minor release rather than a hard break in `2.1`.
+- **`hashCode() != 0` check (PR-1):** removing it is correct per the JDK contract, but confirm no downstream test *relies* on the stricter behavior before deleting.
+- **Behavior-changing contract fixes** (equals no-ops, `newInstanceFull`, mapper extension) may cause *previously-green* downstream projects to newly **fail** — because the library will now actually exercise code paths it silently skipped. This is the correct outcome, but call it out in the release notes so consumers understand why their builds flag real defects after upgrading.
+
+---
+
+*End of plan. Implementation is intentionally out of scope for this document.*


### PR DESCRIPTION
## Summary

Adds `doc/review-26-07-04.md`: a full review of the project (main sources, tests, build/CI, documentation) with a partitioned remediation plan. This PR is **documentation-only** — it introduces the plan, not the fixes. The actual code changes are intentionally out of scope and are partitioned into 10 follow-up PRs described in the document.

## What was reviewed

- **Build baseline:** `./mvnw -B verify` — green, 264 tests, 0 failures/errors on Java 21.
- Four parallel deep reviews covering root/`api`/`junit5`, `contract`/`objects`, `property`/`generator`/`util`, and tests/build/docs.
- Every High-severity finding was manually verified against the source before inclusion.

## Headline findings (all verified)

- **Equals/HashCode contract:** `assertNotEquals(null, underTest)` and `assertNotEquals(new Object(), underTest)` never invoke `underTest.equals(...)` — the null / foreign-type checks are no-ops (`EqualsAndHashcodeContractImpl:321,326`).
- **Instantiators:** `BeanInstantiator.newInstanceFull()` (and `InjectedBeanInstantiator`) populate only optional properties, leaving required ones unset.
- **Generators:** `InterfaceProxyGenerator` shares one static handler, making all proxies of an interface mutually `equals` → `createCopyWithNonEqualValue()` exhausts its retry guard.
- **MapperTest:** omits the generator `@ExtendWith` extensions that `PropertyAwareTest` declares → `@PropertyGenerator` / basic-type registration silently never runs.
- **Collection asserts:** "equal ignoring order" uses two one-way `contains` sweeps → `[a,a,b]` equals `[a,b,b]`.

## PR partitioning

~130 findings grouped into 10 sequenced pull requests, correctness-first:

1. Object-contract correctness (equals/hashCode/serialization)
2. Instantiator & object-creation correctness
3. Generator subsystem correctness
4. Property/reflection/collection-assert correctness
5. MapperTest correctness & API
6. Production Javadoc corrections
7. Project documentation (CLAUDE.md, README, AsciiDoc)
8. Build & CI hygiene
9. Code cleanliness & Java-21 modernization
10. Test-suite improvements

## Notes

- No behavioral change in this PR (adds one Markdown file under `doc/`).
- The document flags API-breaking items and behavior-changing contract fixes so they can be scheduled deliberately (deprecate-then-remove; release notes for downstream projects whose builds may newly flag real defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwUUKJHkjJmLgyM8yzawCY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NwUUKJHkjJmLgyM8yzawCY)_