### PR TITLE
fix(contract): correct object-contract assertions (equals/hashCode/serialization) [PR-1]

### DIFF
--- a/src/main/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImpl.java
@@ -284,10 +284,12 @@ public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
      *
      * @param underTest object under test
      */
-    @SuppressWarnings({"squid:S2159", "squid:S1764"}) // Sonar complains that the x.equals(x) is
-    // always true. This is
-    // only the case if implemented correctly, what is checked
-    // within this test
+    // squid:S2159 / squid:S1764 / PMD.EqualsNull: the x.equals(x), x.equals(null) and
+    // x.equals(new Object()) calls are intentional — verifying the equals contract requires
+    // invoking the object's own equals implementation directly (JUnit's assertNotEquals would
+    // short-circuit and never call it). These hold only when equals is implemented correctly,
+    // which is exactly what this method checks.
+    @SuppressWarnings({"squid:S2159", "squid:S1764", "PMD.EqualsNull"})
     public static void assertBasicContractOnEquals(final Object underTest) {
 
         ReflectionUtil.assertEqualsMethodIsOverriden(underTest.getClass());

--- a/src/main/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImpl.java
@@ -37,9 +37,14 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
 
-    private static final Integer DEFAULT_INT_VALUE = 0;
-
     private static final CuiLogger LOGGER = new CuiLogger(EqualsAndHashcodeContractImpl.class);
+
+    /**
+     * The two most recently added properties are the ones deliberately mutated to an unequal
+     * value while iterating; the remainder is used to build the variant objects. This offset
+     * captures that "keep the last two out of the growing prefix" intent.
+     */
+    private static final int UNEQUAL_VARIANT_OFFSET = 2;
 
     @Override
     public void assertContract(final ParameterizedInstantiator<?> instantiator,
@@ -172,64 +177,39 @@ public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
         final var additionalProperties = nonDefaultProperties.stream().filter(property -> !property.isRequired())
             .toList();
 
-        final var upperBound = Math.min(nonDefaultProperties.size(), consideredAttributes.size()) - 2;
+        final var upperBound = Math.max(0,
+            Math.min(nonDefaultProperties.size(), consideredAttributes.size()) - UNEQUAL_VARIANT_OFFSET);
         if (additionalProperties.isEmpty()) {
             LOGGER.info("Only required or default properties found, therefore no further testing");
         } else {
             final Object minimalObject = instantiator.newInstance(requiredProperties, false);
             final Object fullObject = instantiator.newInstance(allWritableProperties, false);
-            List<PropertySupport> iteratingProperties = new ArrayList<>(requiredProperties);
             // Common Order of properties
-            verifyProperties(instantiator, additionalProperties, upperBound, minimalObject, fullObject, iteratingProperties);
+            verifyProperties(instantiator, additionalProperties, upperBound, minimalObject, fullObject,
+                new ArrayList<>(requiredProperties));
             // reverse Order of additional properties
-            iteratingProperties = new ArrayList<>(requiredProperties);
-            verifyPropertiesInReverse(instantiator, additionalProperties, upperBound, minimalObject, fullObject, iteratingProperties);
+            verifyProperties(instantiator, additionalProperties.reversed(), upperBound, minimalObject, fullObject,
+                new ArrayList<>(requiredProperties));
         }
 
     }
 
     /**
-     * Verifies properties by iterating through additional properties in normal order.
+     * Verifies properties by iterating through the given (already ordered) additional
+     * properties. Callers control the iteration direction by passing the list in the
+     * desired order (e.g. {@link List#reversed()} for reverse iteration).
      *
      * @param instantiator the instantiator used to create test objects
-     * @param additionalProperties the list of additional properties to verify
+     * @param additionalProperties the list of additional properties to verify, in iteration order
      * @param upperBound the upper bound for the number of properties to add
      * @param minimalObject the minimal object for comparison
      * @param fullObject the full object for comparison
      * @param iteratingProperties the list of properties being iterated
      */
-    private static void verifyProperties(ParameterizedInstantiator<?> instantiator, List<PropertySupport> additionalProperties, int upperBound, Object minimalObject, Object fullObject, List<PropertySupport> iteratingProperties) {
+    private static void verifyProperties(ParameterizedInstantiator<?> instantiator,
+        List<PropertySupport> additionalProperties, int upperBound, Object minimalObject, Object fullObject,
+        List<PropertySupport> iteratingProperties) {
         for (final PropertySupport support : additionalProperties) {
-            if (iteratingProperties.size() < upperBound) {
-                iteratingProperties.add(support);
-            } else {
-                // Special case for the last property to be set but the objects
-                // still need to be unequal. For this last property to be iterated the value
-                // will be set to an explicit unequal value:
-                iteratingProperties.add(support.createCopyWithNonEqualValue());
-            }
-            final Object iterating = instantiator.newInstance(iteratingProperties, false);
-            final var current = support.getName();
-            assertEqualObjectAreNotEqual(minimalObject, iterating, current);
-            assertEqualObjectAreNotEqual(fullObject, iterating, current);
-            assertBasicContractOnHashCode(iterating);
-        }
-    }
-
-    /**
-     * Verifies properties by iterating through additional properties in reverse order.
-     *
-     * @param instantiator the instantiator used to create test objects
-     * @param additionalProperties the list of additional properties to verify
-     * @param upperBound the upper bound for the number of properties to add
-     * @param minimalObject the minimal object for comparison
-     * @param fullObject the full object for comparison
-     * @param iteratingProperties the list of properties being iterated
-     */
-    private static void verifyPropertiesInReverse(ParameterizedInstantiator<?> instantiator, List<PropertySupport> additionalProperties, int upperBound, Object minimalObject, Object fullObject, List<PropertySupport> iteratingProperties) {
-        // Iterate in reverse order without creating a copy
-        for (int i = additionalProperties.size() - 1; i >= 0; i--) {
-            final PropertySupport support = additionalProperties.get(i);
             if (iteratingProperties.size() < upperBound) {
                 iteratingProperties.add(support);
             } else {
@@ -267,10 +247,8 @@ public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
             final Object actual = instantiator.newInstance(new ArrayList<>(current.values()), false);
             assertEqualObjectAreNotEqual(expected, actual, name);
         }
-        // Now reverse order - iterate backwards without creating a copy
-        final String[] attributesArray = consideredAttributes.toArray(new String[0]);
-        for (int i = attributesArray.length - 1; i >= 0; i--) {
-            final String name = attributesArray[i];
+        // Now reverse order, using the SequencedCollection#reversed() view (Java 21)
+        for (final String name : consideredAttributes.reversed()) {
             final Map<String, PropertySupport> current = new HashMap<>(allWritableProperties);
             assertTrue(current.containsKey(name), "Invalid configuration found: " + name + " not defined as property.");
             current.put(name, current.get(name).createCopyWithNonEqualValue());
@@ -318,12 +296,15 @@ public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
         final var msgNotEqualsNull = "Expected result for equals(null) will be 'false'. Class was : "
             + underTest.getClass();
 
-        assertNotEquals(null, underTest, msgNotEqualsNull);
+        // Note: the argument order matters. assertNotEquals(null, underTest) / assertNotEquals(new Object(),
+        // underTest) would short-circuit on the JUnit side and never invoke underTest.equals(...), so a broken
+        // equals would pass. We therefore assert directly on underTest.equals(...).
+        assertFalse(underTest.equals(null), msgNotEqualsNull);
 
         final var msgNotEqualsObject = "Expected result for equals(new Object()) will be 'false'. Class was : "
             + underTest.getClass();
 
-        assertNotEquals(new Object(), underTest, msgNotEqualsObject);
+        assertFalse(underTest.equals(new Object()), msgNotEqualsObject);
 
         final var msgEqualsToSelf = "Expected result for equals(underTest) will be 'true'. Class was : "
             + underTest.getClass();
@@ -333,15 +314,22 @@ public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
     }
 
     /**
-     * Verify object has implemented {@link Object#hashCode()} method.
+     * Verify object has implemented {@link Object#hashCode()} method. In addition, it
+     * checks the basic self-consistency requirement of {@link Object#hashCode()}: repeated
+     * invocations on the same object must yield the same result. A {@code hashCode()} of
+     * {@code 0} is perfectly legal (e.g. an object with all-null fields under
+     * {@link java.util.Objects#hash(Object...)}) and must therefore not be rejected.
      *
      * @param underTest object under test
      */
     public static void assertBasicContractOnHashCode(final Object underTest) {
 
-        // basic checks to hashCode implementation
-        assertNotEquals(DEFAULT_INT_VALUE, underTest.hashCode(),
-            "Expected result of hashCode method is not '0'. Class was : " + underTest.getClass());
+        // basic checks to hashCode implementation: it must be consistent across invocations.
+        // A value of 0 is a valid hashCode per the Object#hashCode contract and must not fail.
+        final var firstResult = underTest.hashCode();
+        assertEquals(firstResult, underTest.hashCode(),
+            "hashCode() must consistently return the same value on repeated invocations. Class was : "
+                + underTest.getClass());
     }
 
 }

--- a/src/main/java/de/cuioss/test/valueobjects/contract/SerializableContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/SerializableContractImpl.java
@@ -127,7 +127,7 @@ public class SerializableContractImpl implements ObjectTestContract {
             oas.flush();
         } catch (final IOException e) {
             throw new AssertionError(
-                "Unable to serialize, due to " + ExceptionHelper.extractCauseMessageFromThrowable(e));
+                "Unable to serialize, due to " + ExceptionHelper.extractCauseMessageFromThrowable(e), e);
         }
         return baos.toByteArray();
     }
@@ -145,7 +145,7 @@ public class SerializableContractImpl implements ObjectTestContract {
             return ois.readObject();
         } catch (final IOException | ClassNotFoundException e) {
             throw new AssertionError(
-                "Unable to deserialize, due to " + ExceptionHelper.extractCauseMessageFromThrowable(e));
+                "Unable to deserialize, due to " + ExceptionHelper.extractCauseMessageFromThrowable(e), e);
         }
     }
 

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldBeSerializable.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldBeSerializable.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.io.Serializable;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Simple check whether the returned {@link TestObjectProvider#getUnderTest()}
@@ -41,6 +42,7 @@ public interface ShouldBeSerializable<T> extends TestObjectProvider<T> {
     @Test
     default void shouldImplementSerializable() {
         var underTest = getUnderTest();
+        assertNotNull(underTest, "getUnderTest() must not return null");
         assertInstanceOf(Serializable.class, underTest, underTest.getClass().getName() + " does not implement java.io.Serializable");
         SerializableContractImpl.serializeAndDeserialize(underTest);
     }

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldImplementToString.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldImplementToString.java
@@ -39,6 +39,7 @@ public interface ShouldImplementToString<T> extends TestObjectProvider<T> {
     @Test
     default void shouldImplementToString() {
         var underTest = getUnderTest();
+        assertNotNull(underTest, "getUnderTest() must not return null");
         ReflectionUtil.assertToStringMethodIsOverriden(underTest.getClass());
         assertNotNull(underTest.toString(), "toString must not return 'null'");
     }

--- a/src/test/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImplTest.java
@@ -83,6 +83,33 @@ class EqualsAndHashcodeContractImplTest {
         assertThrows(AssertionError.class, () -> contract.assertContract(instantiator, null));
     }
 
+    /**
+     * Regression test for the equals no-op: {@code equals(null)} must actually be invoked on the
+     * object under test. A bean whose {@code equals(null)} wrongly returns {@code true} passed the
+     * contract before the fix (because {@code assertNotEquals(null, underTest)} short-circuited).
+     */
+    @Test
+    void shouldFailOnBadObjectThatEqualsNull() {
+        var instantiator = new BeanInstantiator<>(new DefaultInstantiator<>(BadObjectBeanEqualsNull.class),
+            EMPTY_RUNTIME_INFORMATION);
+        var contract = new EqualsAndHashcodeContractImpl();
+        assertThrows(AssertionError.class, () -> contract.assertContract(instantiator, null));
+    }
+
+    /**
+     * Regression test for the equals no-op: {@code equals(new Object())} must actually be invoked on
+     * the object under test. A bean whose {@code equals(<foreign type>)} wrongly returns {@code true}
+     * passed the contract before the fix (because {@code assertNotEquals(new Object(), underTest)}
+     * only exercised {@code Object.equals}).
+     */
+    @Test
+    void shouldFailOnBadObjectThatEqualsForeignType() {
+        var instantiator = new BeanInstantiator<>(new DefaultInstantiator<>(BadObjectBeanEqualsForeign.class),
+            EMPTY_RUNTIME_INFORMATION);
+        var contract = new EqualsAndHashcodeContractImpl();
+        assertThrows(AssertionError.class, () -> contract.assertContract(instantiator, null));
+    }
+
     @Test
     void shouldHandleComplexBean() {
         TypedGeneratorRegistry.registerBasicTypes();

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsForeign.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsForeign.java
@@ -15,32 +15,26 @@
  */
 package de.cuioss.test.valueobjects.testbeans.objectcontract;
 
-import java.io.Serializable;
-
 /**
- * Bad bean that neither implements {@link Serializable} nor overrides
- * {@link Object#hashCode()} correctly: its {@code hashCode()} is not consistent across
- * invocations, violating the {@link Object#hashCode()} contract.
+ * Bad bean whose {@link Object#equals(Object)} wrongly returns {@code true} for a
+ * foreign-type argument. This reproduces the historic no-op in
+ * {@code assertBasicContractOnEquals}, where {@code assertNotEquals(new Object(), underTest)}
+ * only invoked {@code Object.equals} (identity) and never {@code underTest.equals(new Object())}:
+ * prior to the fix this bean passed the contract, afterwards it must fail.
  *
  * @author Oliver Wolff
  */
-public class BadObjectBeanWithInvalidHashCode {
-
-    private int counter;
+public class BadObjectBeanEqualsForeign {
 
     @Override
     public boolean equals(final Object obj) {
-        if (null == obj) {
-            return false;
-        }
-        return this == obj;
+        // Broken by design: equals(<foreign type>) must be false, this returns true for any
+        // non-null argument.
+        return null != obj;
     }
 
     @Override
     public int hashCode() {
-        // Bad Boy: violates the consistency requirement of Object#hashCode by returning a
-        // different value on every invocation. (A constant hashCode such as 0 would be perfectly
-        // legal, so it is no longer treated as a contract violation.)
-        return counter++;
+        return 42;
     }
 }

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsNull.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsNull.java
@@ -15,32 +15,28 @@
  */
 package de.cuioss.test.valueobjects.testbeans.objectcontract;
 
-import java.io.Serializable;
-
 /**
- * Bad bean that neither implements {@link Serializable} nor overrides
- * {@link Object#hashCode()} correctly: its {@code hashCode()} is not consistent across
- * invocations, violating the {@link Object#hashCode()} contract.
+ * Bad bean whose {@link Object#equals(Object)} wrongly returns {@code true} for a
+ * {@code null} argument. This reproduces the historic no-op in
+ * {@code assertBasicContractOnEquals}, where {@code assertNotEquals(null, underTest)} never
+ * invoked {@code underTest.equals(null)}: prior to the fix this bean passed the contract,
+ * afterwards it must fail.
  *
  * @author Oliver Wolff
  */
-public class BadObjectBeanWithInvalidHashCode {
-
-    private int counter;
+public class BadObjectBeanEqualsNull {
 
     @Override
     public boolean equals(final Object obj) {
+        // Broken by design: equals(null) must be false, this returns true.
         if (null == obj) {
-            return false;
+            return true;
         }
         return this == obj;
     }
 
     @Override
     public int hashCode() {
-        // Bad Boy: violates the consistency requirement of Object#hashCode by returning a
-        // different value on every invocation. (A constant hashCode such as 0 would be perfectly
-        // legal, so it is no longer treated as a contract violation.)
-        return counter++;
+        return 42;
     }
 }


### PR DESCRIPTION
Implements **PR-1** of `doc/review-26-07-04.md` — object-contract correctness (equals / hashCode / serialization).

## Correctness fixes
- **`EqualsAndHashcodeContractImpl` (H)** — `assertNotEquals(null, underTest)` and `assertNotEquals(new Object(), underTest)` never invoked `underTest.equals(...)` (JUnit short-circuits), so a broken `equals` silently passed. Now asserted directly via `assertFalse(underTest.equals(null))` / `assertFalse(underTest.equals(new Object()))`.
- **`assertBasicContractOnHashCode` (M)** — no longer fails a legal `hashCode()` of `0` (e.g. all-null fields under `Objects.hash`). Replaced with the actual contract requirement: consistency across repeated invocations.
- **`SerializableContractImpl:129,147` (M)** — `AssertionError` now carries the caught exception as its cause (preserves the stack trace).
- **`ShouldBeSerializable:44` (M) / `ShouldImplementToString:42` (L)** — `assertNotNull(underTest)` before dereferencing `getClass()`, so a null under-test yields a clean assertion failure instead of an opaque NPE.

## Cleanup
- Merged the duplicated `verifyProperties` / `verifyPropertiesInReverse` into one method driven by `List#reversed()`.
- Clamped `upperBound` to `>= 0` and named the `-2` offset (`UNEQUAL_VARIANT_OFFSET`).
- Reverse iteration in `assertEqualsAndHashCodeWithChangingProperties` now uses `SequencedCollection#reversed()`.

## Tests (fail on `main`, pass here)
- New `BadObjectBeanEqualsNull` / `BadObjectBeanEqualsForeign` beans + two regression tests proving the `equals` no-op is now caught.
- `BadObjectBeanWithInvalidHashCode` updated to return an *inconsistent* hashCode, matching the corrected consistency-based contract.

`./mvnw clean verify` green on Java 21 (266 tests, +2 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvApYPbcUCtBHU9hxsm8R4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contract checks so incorrect `equals` implementations are now caught when comparing with `null` or unrelated objects.
  * Strengthened `hashCode` validation to verify repeated calls stay consistent.
  * Added safer handling for property-based comparisons and reverse-order checks.

* **Tests**
  * Expanded regression coverage for broken equality and serialization scenarios.
  * Added null-safety checks before verifying serializable and `toString` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->