### PR TITLE
fix(objects): correct instantiator & object-creation logic [PR-2]

### DIFF
--- a/src/main/java/de/cuioss/test/valueobjects/contract/BuilderContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/BuilderContractImpl.java
@@ -18,6 +18,7 @@ package de.cuioss.test.valueobjects.contract;
 import de.cuioss.test.valueobjects.api.TestContract;
 import de.cuioss.test.valueobjects.api.contracts.VerifyBuilder;
 import de.cuioss.test.valueobjects.objects.BuilderInstantiator;
+import de.cuioss.test.valueobjects.objects.ObjectInstantiationException;
 import de.cuioss.test.valueobjects.objects.ParameterizedInstantiator;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.test.valueobjects.objects.impl.BuilderConstructorBasedInstantiator;
@@ -102,14 +103,14 @@ public class BuilderContractImpl<T> implements TestContract<T> {
         for (final PropertyMetadata property : runtimeProperties.getRequiredProperties()) {
             final List<PropertyMetadata> requiredMinusOne = mutableList(runtimeProperties.getRequiredProperties());
             requiredMinusOne.remove(property);
-            var failed = false;
+            var builderAccepted = false;
             try {
                 setAndVerifyProperties(requiredMinusOne);
-                failed = true;
-            } catch (final AssertionError e) {
-                // Expected: Should have been thrown
+                builderAccepted = true;
+            } catch (final ObjectInstantiationException e) {
+                // Expected: the builder correctly rejected the missing required attribute
             }
-            if (failed) {
+            if (builderAccepted) {
                 throw new AssertionError("Property is marked as required but the builder accepts if it is missing: "
                     + property.toString());
             }

--- a/src/main/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImpl.java
@@ -38,10 +38,10 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.*;
 
+import static de.cuioss.tools.base.Preconditions.checkArgument;
 import static de.cuioss.tools.collect.CollectionLiterals.immutableList;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * TestContract for dealing Constructor and factories, {@link VerifyConstructor}
@@ -101,7 +101,7 @@ public class CopyConstructorContractImpl<T> implements TestContract<T> {
             LOGGER.debug("Not checking deep-copy, disabled by configuration");
             return;
         }
-        LOGGER.info("Verifying deep-copy, ignoring properties: {}" + verifyDeepCopyIgnore);
+        LOGGER.info("Verifying deep-copy, ignoring properties: {}", verifyDeepCopyIgnore);
 
         final var all = instantiator.getRuntimeProperties().getAllAsPropertySupport(true);
 
@@ -170,7 +170,7 @@ public class CopyConstructorContractImpl<T> implements TestContract<T> {
         requireNonNull(beanType, "beantype must not be null");
         requireNonNull(initialPropertyMetadata, "initialPropertyMetadata must not be null");
         requireNonNull(existingContracts, "existingContracts must not be null");
-        assertFalse(existingContracts.isEmpty(), "There must be at least one VerifyContract defined");
+        checkArgument(!existingContracts.isEmpty(), "There must be at least one VerifyContract defined");
 
         final var config = configOption.get();
 

--- a/src/main/java/de/cuioss/test/valueobjects/contract/ObjectCreatorContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/ObjectCreatorContractImpl.java
@@ -20,6 +20,7 @@ import de.cuioss.test.valueobjects.api.contracts.VerifyConstructor;
 import de.cuioss.test.valueobjects.api.contracts.VerifyConstructors;
 import de.cuioss.test.valueobjects.api.contracts.VerifyFactoryMethod;
 import de.cuioss.test.valueobjects.api.contracts.VerifyFactoryMethods;
+import de.cuioss.test.valueobjects.objects.ObjectInstantiationException;
 import de.cuioss.test.valueobjects.objects.ParameterizedInstantiator;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.test.valueobjects.objects.impl.ConstructorBasedInstantiator;
@@ -73,14 +74,14 @@ public class ObjectCreatorContractImpl<T> implements TestContract<T> {
                 final List<PropertySupport> iterating = new ArrayList<>(required);
                 iterating.remove(support);
                 iterating.add(support.createCopy(false));
-                var failed = false;
+                var constructorAccepted = false;
                 try {
                     getInstantiator().newInstance(iterating, false);
-                    failed = true;
-                } catch (final AssertionError e) {
-                    // expected
+                    constructorAccepted = true;
+                } catch (final ObjectInstantiationException e) {
+                    // Expected: the object under test correctly rejected the missing required attribute
                 }
-                if (failed) {
+                if (constructorAccepted) {
                     throw new AssertionError("Object Should not build due to missing required attribute " + support);
                 }
             }
@@ -150,6 +151,7 @@ public class ObjectCreatorContractImpl<T> implements TestContract<T> {
         final Class<?> annotated, final List<PropertyMetadata> initialPropertyMetadata) {
 
         requireNonNull(beanType, "beantype must not be null");
+        requireNonNull(annotated, "annotated must not be null");
         requireNonNull(initialPropertyMetadata, "initialPropertyMetadata must not be null");
 
         final var builder = new CollectionBuilder<ObjectCreatorContractImpl<T>>();

--- a/src/main/java/de/cuioss/test/valueobjects/contract/ReflectionUtil.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/ReflectionUtil.java
@@ -97,17 +97,13 @@ public final class ReflectionUtil {
      */
     private static Method getMethodFromClass(final Class<?> clazz, final String methodName, final Class<?>[] args1) {
         assertNotNull(clazz, "Target for test is null");
-        Method result = null;
         try {
             if (null != args1) {
-                result = clazz.getMethod(methodName, args1);
-            } else {
-                result = clazz.getMethod(methodName);
+                return clazz.getMethod(methodName, args1);
             }
+            return clazz.getMethod(methodName);
         } catch (final SecurityException | NoSuchMethodException e) {
             throw new AssertionError(e);
         }
-        assertNotNull(result, "Method " + methodName + " does not exist on " + clazz);
-        return result;
     }
 }

--- a/src/main/java/de/cuioss/test/valueobjects/objects/ObjectInstantiationException.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/ObjectInstantiationException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.valueobjects.objects;
+
+import java.io.Serial;
+
+/**
+ * Dedicated {@link AssertionError} raised by the different
+ * {@link ParameterizedInstantiator} / {@link BuilderInstantiator}
+ * implementations when the actual reflective creation of an object (invoking a
+ * constructor, factory- or builder-method) fails. Most prominently this is the
+ * signal that a required property was missing and the object under test
+ * correctly rejected the creation.
+ * <p>
+ * Having a dedicated type allows the contract implementations to distinguish
+ * this <em>expected</em> rejection from unrelated {@link AssertionError}s (e.g.
+ * a failing value assertion), which must always surface instead of being
+ * silently swallowed.
+ * <p>
+ * It extends {@link AssertionError} in order to stay backwards compatible with
+ * callers that only expect an {@link AssertionError} to be thrown on
+ * instantiation failure.
+ *
+ * @author Oliver Wolff
+ */
+public class ObjectInstantiationException extends AssertionError {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message describing the instantiation failure
+     * @param cause   the underlying cause, may be null
+     */
+    public ObjectInstantiationException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param message describing the instantiation failure
+     */
+    public ObjectInstantiationException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractInlineInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractInlineInstantiator.java
@@ -34,9 +34,6 @@ import java.util.List;
  */
 public abstract class AbstractInlineInstantiator<T> implements ParameterizedInstantiator<T> {
 
-    /** "Properties must not be null, but may be empty". */
-    public static final String PROPERTIES_MUST_NOT_BE_NULL = "Properties must not be null, but may be empty";
-
     @Override
     public T newInstance(final List<PropertySupport> properties, final boolean generatePropertyValues) {
         return any();

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractOrderedArgsInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractOrderedArgsInstantiator.java
@@ -85,9 +85,7 @@ public abstract class AbstractOrderedArgsInstantiator<T> implements Parameterize
                 }
                 parameter.add(givenSupport.getGeneratedValue());
             } else {
-                if (null != support.getGeneratedValue()) {
-                    // A Test value is already set
-                } else if (support.isRequired() || support.isPrimitive()) {
+                if (null == support.getGeneratedValue() && (support.isRequired() || support.isPrimitive())) {
                     support.generateTestValue();
                 }
                 parameter.add(support.getGeneratedValue());

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BeanInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BeanInstantiator.java
@@ -27,7 +27,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-import static de.cuioss.test.valueobjects.objects.impl.AbstractInlineInstantiator.PROPERTIES_MUST_NOT_BE_NULL;
+import static de.cuioss.test.valueobjects.objects.impl.InstantiatorConstants.PROPERTIES_MUST_NOT_BE_NULL;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -78,7 +78,7 @@ public class BeanInstantiator<T> implements ParameterizedInstantiator<T> {
 
     @Override
     public T newInstanceFull() {
-        return newInstance(runtimeProperties.getAdditionalProperties());
+        return newInstance(runtimeProperties.getWritableProperties());
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderConstructorBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderConstructorBasedInstantiator.java
@@ -17,6 +17,7 @@ package de.cuioss.test.valueobjects.objects.impl;
 
 import de.cuioss.test.valueobjects.contract.BuilderContractImpl;
 import de.cuioss.test.valueobjects.objects.BuilderInstantiator;
+import de.cuioss.test.valueobjects.objects.ObjectInstantiationException;
 import de.cuioss.test.valueobjects.objects.ObjectInstantiator;
 import lombok.Getter;
 import lombok.ToString;
@@ -79,13 +80,27 @@ public class BuilderConstructorBasedInstantiator<T> implements BuilderInstantiat
         builderInstantiator = new DefaultInstantiator<>(builderType);
 
         try {
-            builderMethod = builderInstantiator.getTargetClass().getDeclaredMethod(buildMethodName);
+            builderMethod = resolveBuildMethod(builderInstantiator.getTargetClass(), buildMethodName);
             targetClass = (Class<T>) builderMethod.getReturnType();
         } catch (NoSuchMethodException | SecurityException e) {
             throw new AssertionError("Unable to access method " + buildMethodName + " on type " + builderType.getName()
                 + ", due to " + extractCauseMessageFromThrowable(e), e);
         }
 
+    }
+
+    /**
+     * Resolves the build method. It first tries the methods declared on the given
+     * type and falls back to {@link Class#getMethod(String, Class...)} in order to
+     * also find methods inherited from a (potentially abstract) superclass.
+     */
+    private static Method resolveBuildMethod(final Class<?> builderClass, final String buildMethodName)
+        throws NoSuchMethodException {
+        try {
+            return builderClass.getDeclaredMethod(buildMethodName);
+        } catch (NoSuchMethodException e) {
+            return builderClass.getMethod(buildMethodName);
+        }
     }
 
     @Override
@@ -99,7 +114,7 @@ public class BuilderConstructorBasedInstantiator<T> implements BuilderInstantiat
         try {
             return (T) builderMethod.invoke(builder);
         } catch (IllegalAccessException | InvocationTargetException | RuntimeException e) {
-            throw new AssertionError("Unable to access method " + builderMethod.getName() + " on type "
+            throw new ObjectInstantiationException("Unable to access method " + builderMethod.getName() + " on type "
                 + getBuilderClass().getName() + ", due to " + extractCauseMessageFromThrowable(e), e);
         }
     }

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderFactoryBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderFactoryBasedInstantiator.java
@@ -17,6 +17,7 @@ package de.cuioss.test.valueobjects.objects.impl;
 
 import de.cuioss.test.valueobjects.contract.BuilderContractImpl;
 import de.cuioss.test.valueobjects.objects.BuilderInstantiator;
+import de.cuioss.test.valueobjects.objects.ObjectInstantiationException;
 import de.cuioss.tools.logging.CuiLogger;
 import lombok.Getter;
 import lombok.ToString;
@@ -46,6 +47,8 @@ public class BuilderFactoryBasedInstantiator<T> implements BuilderInstantiator<T
 
     private final Method builderFactoryMethod;
     private final Method builderMethod;
+
+    private final Class<?> enclosingType;
 
     @Getter
     private final Class<T> targetClass;
@@ -85,8 +88,10 @@ public class BuilderFactoryBasedInstantiator<T> implements BuilderInstantiator<T
         requireNonNull(builderMethodName, "builderMethodName must not be null");
         requireNonNull(builderFactoryMethodName, "builderFactoryMethodName must not be null");
 
+        this.enclosingType = enclosingType;
+
         try {
-            builderFactoryMethod = enclosingType.getDeclaredMethod(builderFactoryMethodName);
+            builderFactoryMethod = resolveMethod(enclosingType, builderFactoryMethodName);
             builderClass = builderFactoryMethod.getReturnType();
         } catch (NoSuchMethodException | SecurityException e) {
             final var message = UNABLE_TO_ACCESS_METHOD.formatted(builderFactoryMethodName, enclosingType.getName(),
@@ -96,7 +101,7 @@ public class BuilderFactoryBasedInstantiator<T> implements BuilderInstantiator<T
         }
 
         try {
-            builderMethod = builderClass.getDeclaredMethod(builderMethodName);
+            builderMethod = resolveMethod(builderClass, builderMethodName);
             targetClass = (Class<T>) builderMethod.getReturnType();
         } catch (NoSuchMethodException | SecurityException e) {
             final var message = UNABLE_TO_ACCESS_METHOD.formatted(builderMethodName, builderClass,
@@ -107,13 +112,27 @@ public class BuilderFactoryBasedInstantiator<T> implements BuilderInstantiator<T
 
     }
 
+    /**
+     * Resolves a parameter-free method. It first tries the methods declared on the
+     * given type and falls back to {@link Class#getMethod(String, Class...)} in
+     * order to also find methods inherited from a (potentially abstract)
+     * superclass.
+     */
+    private static Method resolveMethod(final Class<?> owner, final String methodName) throws NoSuchMethodException {
+        try {
+            return owner.getDeclaredMethod(methodName);
+        } catch (NoSuchMethodException e) {
+            return owner.getMethod(methodName);
+        }
+    }
+
     @Override
     public Object newBuilderInstance() {
         try {
             return builderFactoryMethod.invoke(null);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            final var message = UNABLE_TO_ACCESS_METHOD.formatted(builderFactoryMethod.getName(), targetClass,
-                extractCauseMessageFromThrowable(e));
+            final var message = UNABLE_TO_ACCESS_METHOD.formatted(builderFactoryMethod.getName(),
+                enclosingType.getName(), extractCauseMessageFromThrowable(e));
             LOGGER.error(e, message);
             throw new AssertionError(message, e);
         }
@@ -128,7 +147,7 @@ public class BuilderFactoryBasedInstantiator<T> implements BuilderInstantiator<T
             final var message = UNABLE_TO_ACCESS_METHOD.formatted(builderMethod.getName(), builderClass.getName(),
                 extractCauseMessageFromThrowable(e));
             LOGGER.debug(message, e);
-            throw new AssertionError(message, e);
+            throw new ObjectInstantiationException(message, e);
         }
     }
 }

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderParameterizedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderParameterizedInstantiator.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-import static de.cuioss.test.valueobjects.objects.impl.AbstractInlineInstantiator.PROPERTIES_MUST_NOT_BE_NULL;
+import static de.cuioss.test.valueobjects.objects.impl.InstantiatorConstants.PROPERTIES_MUST_NOT_BE_NULL;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -76,7 +76,8 @@ public class BuilderParameterizedInstantiator<T> implements ParameterizedInstant
 
     @Override
     public String toString() {
-        return getClass().getName() + "\nInstantiator: " + instantiator + runtimeProperties;
+        return getClass().getName() + "\nInstantiator: " + instantiator
+            + "\nProperty Configuration: " + runtimeProperties;
     }
 
 }

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/ConstructorBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/ConstructorBasedInstantiator.java
@@ -15,6 +15,7 @@
  */
 package de.cuioss.test.valueobjects.objects.impl;
 
+import de.cuioss.test.valueobjects.objects.ObjectInstantiationException;
 import de.cuioss.test.valueobjects.objects.ParameterizedInstantiator;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.tools.logging.CuiLogger;
@@ -65,7 +66,6 @@ public class ConstructorBasedInstantiator<T> extends AbstractOrderedArgsInstanti
             } else {
                 constructor = type.getConstructor(toClassArray(parameter));
             }
-            requireNonNull(constructor, "Unable to find a constructor with signature " + parameter);
         } catch (NoSuchMethodException | SecurityException e) {
             final var message = "Unable to find a constructor with signature " + parameter +
                 ", for type " + type.getName();
@@ -76,7 +76,7 @@ public class ConstructorBasedInstantiator<T> extends AbstractOrderedArgsInstanti
             if (0 == type.getConstructors().length) {
                 LOGGER.error("No public constructor found!");
             }
-            throw new AssertionError(message);
+            throw new AssertionError(message, e);
         }
     }
 
@@ -86,9 +86,9 @@ public class ConstructorBasedInstantiator<T> extends AbstractOrderedArgsInstanti
             return constructor.newInstance(args);
         } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
             | InvocationTargetException e) {
-            final var message = "Unable to invoke constructor " + ", due to " +
+            final var message = "Unable to invoke constructor, due to " +
                 extractCauseMessageFromThrowable(e);
-            throw new AssertionError(message, e);
+            throw new ObjectInstantiationException(message, e);
         }
     }
 

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/FactoryBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/FactoryBasedInstantiator.java
@@ -15,12 +15,14 @@
  */
 package de.cuioss.test.valueobjects.objects.impl;
 
+import de.cuioss.test.valueobjects.objects.ObjectInstantiationException;
 import de.cuioss.test.valueobjects.objects.ParameterizedInstantiator;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.tools.logging.CuiLogger;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +30,6 @@ import static de.cuioss.test.valueobjects.objects.impl.ExceptionHelper.extractCa
 import static de.cuioss.tools.base.Preconditions.checkArgument;
 import static de.cuioss.tools.string.MoreStrings.isEmpty;
 import static java.util.Objects.requireNonNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -69,21 +70,34 @@ public class FactoryBasedInstantiator<T> extends AbstractOrderedArgsInstantiator
         final List<Class<?>> parameter = new ArrayList<>();
         runtimeProperties.getAllProperties().forEach(meta -> parameter.add(meta.resolveActualClass()));
         try {
-            if (parameter.isEmpty()) {
-                factoryMethod = enclosingType.getDeclaredMethod(factoryMethodName);
-            } else {
-                factoryMethod = enclosingType.getDeclaredMethod(factoryMethodName, toClassArray(parameter));
-            }
-            assertNotNull(
-
-                factoryMethod,
-                "Unable to find a factory method with signature " + parameter + " and name " + factoryMethodName);
+            factoryMethod = resolveFactoryMethod(enclosingType, factoryMethodName, toClassArray(parameter));
             assertTrue(type.isAssignableFrom(factoryMethod.getReturnType()),
                 "Invalid type found on factory method: " + factoryMethod.getReturnType());
+            checkArgument(Modifier.isStatic(factoryMethod.getModifiers()),
+                "Factory method '" + factoryMethodName + "' on " + enclosingType.getName()
+                    + " must be static in order to be usable as a factory method");
         } catch (NoSuchMethodException | SecurityException e) {
-            final var message = "Unable to find a constructor with signature " + parameter;
+            final var message = "Unable to find factory method '" + factoryMethodName + "' on "
+                + enclosingType.getName() + " with signature " + parameter;
             LOGGER.error(e, message);
-            throw new AssertionError(message);
+            throw new AssertionError(message, e);
+        }
+    }
+
+    /**
+     * Resolves the factory method. It first tries the methods declared on the
+     * given type and falls back to {@link Class#getMethod(String, Class...)} in
+     * order to also find methods inherited from a (potentially abstract)
+     * superclass.
+     */
+    private static Method resolveFactoryMethod(final Class<?> enclosingType, final String factoryMethodName,
+        final Class<?>[] parameterTypes) throws NoSuchMethodException {
+        try {
+            return enclosingType.getDeclaredMethod(factoryMethodName, parameterTypes);
+        } catch (NoSuchMethodException e) {
+            LOGGER.debug(e, "No declared method '%s' found, falling back to inherited public methods",
+                factoryMethodName);
+            return enclosingType.getMethod(factoryMethodName, parameterTypes);
         }
     }
 
@@ -93,9 +107,9 @@ public class FactoryBasedInstantiator<T> extends AbstractOrderedArgsInstantiator
         try {
             return (T) factoryMethod.invoke(null, args);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            final var message = "Unable to invoke constructor " + ", due to " +
+            final var message = "Unable to invoke factory method, due to " +
                 extractCauseMessageFromThrowable(e);
-            throw new AssertionError(message, e);
+            throw new ObjectInstantiationException(message, e);
         }
     }
 

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/InjectedBeanInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/InjectedBeanInstantiator.java
@@ -28,7 +28,7 @@ import lombok.RequiredArgsConstructor;
 import java.io.Serializable;
 import java.util.List;
 
-import static de.cuioss.test.valueobjects.objects.impl.AbstractInlineInstantiator.PROPERTIES_MUST_NOT_BE_NULL;
+import static de.cuioss.test.valueobjects.objects.impl.InstantiatorConstants.PROPERTIES_MUST_NOT_BE_NULL;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
@@ -43,8 +43,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @RequiredArgsConstructor
 public class InjectedBeanInstantiator<T> implements ParameterizedInstantiator<T> {
 
+    @NonNull
     private final TestObjectProvider<T> objectProvider;
 
+    @NonNull
     private final ConfigurationCallBackHandler<T> callbackHandler;
 
     @Getter
@@ -68,7 +70,7 @@ public class InjectedBeanInstantiator<T> implements ParameterizedInstantiator<T>
 
     @Override
     public T newInstanceFull() {
-        return newInstance(runtimeProperties.getAdditionalProperties());
+        return newInstance(runtimeProperties.getWritableProperties());
     }
 
     @Override

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/InstantiatorConstants.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/InstantiatorConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.valueobjects.objects.impl;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Aggregates constants shared between the different instantiator
+ * implementations within this package.
+ *
+ * @author Oliver Wolff
+ */
+@UtilityClass
+final class InstantiatorConstants {
+
+    /** "Properties must not be null, but may be empty". */
+    static final String PROPERTIES_MUST_NOT_BE_NULL = "Properties must not be null, but may be empty";
+}

--- a/src/test/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImplTest.java
@@ -65,7 +65,7 @@ class CopyConstructorContractImplTest {
     @SuppressWarnings("java:S5778")
     // owolff Collections.emptyList() considered unproblematic
     void shouldFailToDetermineContractOnEmptyInstantiatorList() {
-        assertThrows(AssertionError.class, () ->
+        assertThrows(IllegalArgumentException.class, () ->
             createTestContract(OneRequiredFieldCopyConstructor.class, OneRequiredFieldCopyConstructor.class,
                 OneRequiredFieldCopyConstructor.ATTRIBUTE_LIST, Collections.emptyList()));
     }


### PR DESCRIPTION
Implements **PR-2** of `doc/review-26-07-04.md` — instantiator & object-creation correctness (18 findings).

## Correctness
- **`BeanInstantiator.newInstanceFull()` (H)** and **`InjectedBeanInstantiator` (M)** — now apply all *writable* properties (required + additional) via `getWritableProperties()`, instead of only the non-required `getAdditionalProperties()`, so `anyValueObject()` gets a fully-populated instance.
- **`FactoryBasedInstantiator` (M)** — validates the configured factory method is `static` (descriptive `IllegalArgumentException` instead of a raw NPE).
- **Inherited-method lookup (M)** — `FactoryBasedInstantiator`, `BuilderConstructorBasedInstantiator`, `BuilderFactoryBasedInstantiator` fall back to `getMethod(...)` when `getDeclaredMethod(...)` misses a `build()`/factory method inherited from an abstract superclass.
- **Precise rejection detection (M)** — new `ObjectInstantiationException` (extends `AssertionError` for back-compat) is thrown by the instantiators and caught specifically by `ObjectCreatorContractImpl` / `BuilderContractImpl`, so a bare `catch (AssertionError)` no longer masks unrelated failures.
- **Lost stack traces (M)** — `AssertionError`s in `ConstructorBasedInstantiator` / `FactoryBasedInstantiator` now carry the cause.
- **Inverted `failed` flag (M)** — renamed to `builderAccepted` / `constructorAccepted` with correct polarity.

## Diagnostics & cleanup
- Corrected factory-vs-constructor wording and stray `" , due to"` concatenation; `BuilderFactoryBasedInstantiator` reports the real enclosing type; `CopyConstructorContractImpl` uses the `{}` placeholder and `checkArgument` for argument validation; `ObjectCreatorContractImpl` null-checks `annotated`.
- Removed dead null checks (`ConstructorBasedInstantiator`, `FactoryBasedInstantiator`, `ReflectionUtil`) and a dead branch in `AbstractOrderedArgsInstantiator`.
- Moved the shared `PROPERTIES_MUST_NOT_BE_NULL` constant to a new package-private `InstantiatorConstants`; added `@NonNull` to `InjectedBeanInstantiator` fields; fixed `BuilderParameterizedInstantiator.toString()` separators.

`./mvnw clean verify` green on Java 21 (264 tests). One test (`CopyConstructorContractImplTest`) updated to assert the now-more-precise `IllegalArgumentException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvApYPbcUCtBHU9hxsm8R4)_