### PR TITLE
fix(generator): correct generator subsystem (proxy equality, registry, recursion) [PR-3]

### DIFF
--- a/src/main/java/de/cuioss/test/valueobjects/generator/TypedGeneratorRegistry.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/TypedGeneratorRegistry.java
@@ -60,10 +60,7 @@ public final class TypedGeneratorRegistry {
     @SuppressWarnings("unchecked")
     public static <T> Optional<TypedGenerator<T>> getGenerator(final Class<T> type) {
         requireNonNull(type, TYPE_MUST_NOT_BE_NULL);
-        if (!REGISTRY.containsKey(type)) {
-            return Optional.empty();
-        }
-        return Optional.of((TypedGenerator<T>) REGISTRY.get(type));
+        return Optional.ofNullable((TypedGenerator<T>) REGISTRY.get(type));
     }
 
     /**

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolver.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolver.java
@@ -19,14 +19,17 @@ import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
 import de.cuioss.test.valueobjects.generator.TypedGeneratorRegistry;
 import de.cuioss.test.valueobjects.generator.dynamic.impl.*;
+import de.cuioss.test.valueobjects.generator.impl.DummyGenerator;
 import de.cuioss.test.valueobjects.property.util.CollectionType;
 import de.cuioss.tools.logging.CuiLogger;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -43,6 +46,14 @@ public final class GeneratorResolver {
     private static final String TYPE_MUST_NOT_BE_NULL = "type must not be null";
 
     private static final CuiLogger LOGGER = new CuiLogger(GeneratorResolver.class);
+
+    /**
+     * Tracks the types that are currently being resolved on the calling thread. It
+     * is used to break cycles between mutually recursive types (e.g. {@code A}
+     * referencing {@code B} and {@code B} referencing {@code A}) that would
+     * otherwise result in a {@link StackOverflowError}.
+     */
+    private static final ThreadLocal<Set<Class<?>>> IN_PROGRESS_TYPES = ThreadLocal.withInitial(HashSet::new);
 
     /**
      * Central method for finding / accessing a concrete {@link TypedGenerator} for
@@ -65,7 +76,26 @@ public final class GeneratorResolver {
             LOGGER.trace(FOUND_GENERATOR_FOR_TYPE, found.get().getClass().getName(), type.getName());
             return found.get();
         }
-        found = Generators.enumValuesIfAvailable(type);
+        final var inProgress = IN_PROGRESS_TYPES.get();
+        if (!inProgress.add(type)) {
+            // Re-entrant resolution of the same type: this happens for mutually
+            // recursive types (A -> B -> A). Returning a DummyGenerator breaks the
+            // cycle cleanly instead of running into a StackOverflowError.
+            LOGGER.debug("Detected recursive resolution for type %s, returning DummyGenerator", type.getName());
+            return new DummyGenerator<>(type);
+        }
+        try {
+            return resolveGeneratorInternal(type);
+        } finally {
+            inProgress.remove(type);
+            if (inProgress.isEmpty()) {
+                IN_PROGRESS_TYPES.remove();
+            }
+        }
+    }
+
+    private static <T> TypedGenerator<T> resolveGeneratorInternal(final Class<T> type) {
+        Optional<TypedGenerator<T>> found = Generators.enumValuesIfAvailable(type);
         if (found.isPresent()) {
             TypedGeneratorRegistry.registerGenerator(found.get());
             LOGGER.trace(FOUND_GENERATOR_FOR_TYPE, found.get().getClass().getName(), type.getName());
@@ -114,8 +144,8 @@ public final class GeneratorResolver {
      * {@link Collection} or {@link Map}s for given interfaces
      *
      * @param type to be checked
-     * @return an {@link TypedGenerator} if applicable or or <code>not
-     *         {@link Optional#isPresent()}</code>
+     * @return an {@link TypedGenerator} if applicable or {@link Optional#empty()}
+     *         otherwise
      */
     @SuppressWarnings("unchecked") // Checked beforehand
     public static <T> Optional<TypedGenerator<T>> resolveCollectionGenerator(final Class<T> type) {

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ArraysGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ArraysGenerator.java
@@ -61,7 +61,7 @@ public class ArraysGenerator<T, C> implements TypedGenerator<T> {
     /**
      * Factory method for creating an instance of {@link ArraysGenerator}.
      *
-     * @param type to be, must not be an array type: {@link Class#isArray()}
+     * @param type to be checked, must be an array type: {@link Class#isArray()}
      * @return an {@link Optional} on the corresponding {@link ArraysGenerator} if
      *         the requirements are met, {@link Optional#empty()} otherwise
      */

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGenerator.java
@@ -97,7 +97,8 @@ public class ConstructorBasedGenerator<T> implements TypedGenerator<T> {
     private static String logUsedValuesForConstructor(final ArrayList<Object> parameter) {
         final List<String> parameterInfo = new ArrayList<>();
         for (final Object object : parameter) {
-            parameterInfo.add("[" + object.getClass().getSimpleName() + " " + object + "]");
+            final var simpleName = null == object ? "null" : object.getClass().getSimpleName();
+            parameterInfo.add("[" + simpleName + " " + object + "]");
         }
         return Joiner.on(", ").skipNulls().join(parameterInfo);
     }
@@ -192,7 +193,10 @@ public class ConstructorBasedGenerator<T> implements TypedGenerator<T> {
                 LOGGER.debug("Skipping copy constructor...");
                 continue;
             }
-            return createForConstructor(type, con);
+            final Optional<TypedGenerator<T>> generator = createForConstructor(type, con);
+            if (generator.isPresent()) {
+                return generator;
+            }
         }
         throw new IllegalStateException("No matching constructor found for class " + type);
     }

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGenerator.java
@@ -23,6 +23,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+import java.lang.reflect.Modifier;
 import java.util.Optional;
 
 /**
@@ -64,14 +65,20 @@ public class DynamicProxyGenerator<T> implements TypedGenerator<T> {
      *         the given type is applicable, otherwise {@link Optional#empty()}
      */
     public static final <T> Optional<TypedGenerator<T>> getGeneratorForType(final Class<T> type) {
-        if (null == type || type.isAnnotation() || type.isInterface() || type.isEnum()) {
+        if (null == type || type.isAnnotation() || type.isInterface() || type.isEnum()
+            || Modifier.isFinal(type.getModifiers())) {
+            // final classes cannot be subclassed by javassist, so a proxy cannot be created
             return Optional.empty();
         }
-        final var proxyFactory = new ProxyFactory();
-        proxyFactory.setSuperclass(type);
-        proxyFactory.setFilter(m -> "equals".equals(m.getName()));
-
-        Class<?> createClassType = proxyFactory.createClass();
+        final Class<?> createClassType;
+        try {
+            final var proxyFactory = new ProxyFactory();
+            proxyFactory.setSuperclass(type);
+            createClassType = proxyFactory.createClass();
+        } catch (final RuntimeException e) {
+            LOGGER.warn(e, "Unable to create javassist proxy for type %s", type);
+            return Optional.empty();
+        }
         @SuppressWarnings("unchecked") final Optional<TypedGenerator<T>> constructorGenerator = ConstructorBasedGenerator
             .getGeneratorForType((Class<T>) createClassType);
         if (constructorGenerator.isPresent()) {

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGenerator.java
@@ -20,7 +20,6 @@ import de.cuioss.tools.reflect.MoreReflection;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-import java.lang.reflect.InvocationHandler;
 import java.util.Optional;
 
 /**
@@ -33,13 +32,15 @@ import java.util.Optional;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class InterfaceProxyGenerator<T> implements TypedGenerator<T> {
 
-    private static final InvocationHandler DEFAULT_HANDLER = new DefaultInvocationHandler();
-
     private final Class<T> type;
 
     @Override
     public T next() {
-        return MoreReflection.newProxy(type, DEFAULT_HANDLER);
+        // A fresh handler must be created for each proxy: DefaultInvocationHandler
+        // compares proxies by handler identity, so sharing a single static handler
+        // would make all generated proxies of an interface mutually equal and share
+        // their hashCode, exhausting PropertySupport.createCopyWithNonEqualValue().
+        return MoreReflection.newProxy(type, new DefaultInvocationHandler());
     }
 
     @Override

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolverTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolverTest.java
@@ -95,7 +95,47 @@ class GeneratorResolverTest {
     }
 
     @Test
+    void shouldHandleMutuallyRecursiveTypes() {
+        TypedGeneratorRegistry.registerBasicTypes();
+        // RecursiveA references RecursiveB and vice versa. Without the re-entry guard
+        // this would run into a StackOverflowError. The guard returns a DummyGenerator
+        // for the type that is currently being resolved, breaking the cycle.
+        final TypedGenerator<RecursiveA> generator = assertDoesNotThrow(() -> resolveGenerator(RecursiveA.class));
+        assertNotNull(generator);
+        // next() exercises the non-public constructor logging path, including the
+        // null-value produced by the DummyGenerator that broke the cycle.
+        final RecursiveA instance = assertDoesNotThrow(generator::next);
+        assertNotNull(instance);
+    }
+
+    @Test
     void shouldFailToHandleAnnotations() {
         assertThrows(IllegalArgumentException.class, () -> resolveGenerator(VetoObjectTestContract.class));
+    }
+
+    /**
+     * Fixture forming a mutually recursive type-pair with {@link RecursiveB}. The
+     * package-private constructor additionally exercises the non-public constructor
+     * logging path of the {@code ConstructorBasedGenerator}.
+     */
+    static class RecursiveA {
+
+        final RecursiveB other;
+
+        RecursiveA(final RecursiveB other) {
+            this.other = other;
+        }
+    }
+
+    /**
+     * Counterpart of {@link RecursiveA}, closing the resolution cycle.
+     */
+    static class RecursiveB {
+
+        final RecursiveA other;
+
+        RecursiveB(final RecursiveA other) {
+            this.other = other;
+        }
     }
 }

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGeneratorTest.java
@@ -116,4 +116,68 @@ class ConstructorBasedGeneratorTest {
         assertFalse(getGeneratorForType(AbstractList.class).isPresent());
         assertFalse(getGeneratorForType(VetoObjectTestContract.class).isPresent());
     }
+
+    @Test
+    void shouldResolveViaLastResortConstructorLoop() {
+        // Multiple constructors, none of whose parameter types have a pre-registered
+        // generator (CustomDependency is not a basic type). This forces the resolution
+        // to fall through into the last-resort loop that tries each constructor until
+        // one yields a generator.
+        final var optional = getGeneratorForType(BeanWithMultipleUnregisteredConstructors.class);
+        assertTrue(optional.isPresent());
+        final var next = optional.get().next();
+        assertNotNull(next);
+        assertEquals(BeanWithMultipleUnregisteredConstructors.class, next.getClass());
+    }
+
+    /**
+     * Fixture whose parameter type is not a registered basic type.
+     */
+    public static class CustomDependency {
+
+        public CustomDependency() {
+        }
+    }
+
+    /**
+     * Fixture with more than one public constructor, none of which can be satisfied
+     * from already registered generators, forcing the last-resort constructor loop.
+     */
+    public static class BeanWithMultipleUnregisteredConstructors {
+
+        public BeanWithMultipleUnregisteredConstructors(final CustomDependency dependency) {
+        }
+
+        public BeanWithMultipleUnregisteredConstructors(final CustomDependency dependency,
+            final CustomDependency other) {
+        }
+    }
+
+    @Test
+    void shouldSkipNonResolvableConstructorInLastResortLoop() {
+        // In the last-resort loop the first (multi-argument) constructor references the
+        // type itself and therefore yields no generator; the loop must skip it and pick
+        // the next resolvable constructor instead of failing.
+        final var optional = getGeneratorForType(BeanWithSelfReferencingConstructor.class);
+        assertTrue(optional.isPresent());
+        final var next = optional.get().next();
+        assertNotNull(next);
+        assertEquals(BeanWithSelfReferencingConstructor.class, next.getClass());
+    }
+
+    /**
+     * Fixture forcing the last-resort loop where the first candidate constructor
+     * references the type itself (yielding an empty generator that must be skipped)
+     * while a later constructor is resolvable.
+     */
+    public static class BeanWithSelfReferencingConstructor {
+
+        public BeanWithSelfReferencingConstructor(final BeanWithSelfReferencingConstructor self,
+            final CustomDependency dependency) {
+        }
+
+        public BeanWithSelfReferencingConstructor(final CustomDependency first, final CustomDependency second,
+            final CustomDependency third) {
+        }
+    }
 }

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGeneratorTest.java
@@ -17,6 +17,7 @@ package de.cuioss.test.valueobjects.generator.dynamic.impl;
 
 import de.cuioss.test.valueobjects.api.object.VetoObjectTestContract;
 import de.cuioss.tools.property.PropertyMemberInfo;
+import javassist.util.proxy.ProxyFactory;
 import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
@@ -56,5 +57,23 @@ class DynamicProxyGeneratorTest {
         assertFalse(getGeneratorForType(PropertyMemberInfo.class).isPresent());
         assertFalse(getGeneratorForType(Serializable.class).isPresent());
         assertFalse(getGeneratorForType(VetoObjectTestContract.class).isPresent());
+    }
+
+    @Test
+    void shouldNotHandleFinalClasses() {
+        // final classes cannot be subclassed by javassist, so no proxy can be created
+        assertFalse(getGeneratorForType(String.class).isPresent());
+        assertFalse(getGeneratorForType(Integer.class).isPresent());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenProxyCreationFails() {
+        // A javassist proxy class already declares the setHandler() method. Asking
+        // javassist to subclass such a proxy class again fails with a RuntimeException,
+        // which must be caught, resulting in an empty Optional instead of propagating.
+        final var factory = new ProxyFactory();
+        factory.setSuperclass(ArrayList.class);
+        final Class<?> alreadyProxied = factory.createClass();
+        assertFalse(getGeneratorForType(alreadyProxied).isPresent());
     }
 }

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGeneratorTest.java
@@ -51,6 +51,20 @@ class InterfaceProxyGeneratorTest {
     }
 
     @Test
+    void shouldCreateNonEqualProxiesOnSubsequentNextCalls() {
+        final var generator = getGeneratorForType(SortedSet.class).get();
+        final var first = generator.next();
+        final var second = generator.next();
+        assertNotNull(first);
+        assertNotNull(second);
+        // Each proxy must have its own InvocationHandler; otherwise all proxies of an
+        // interface would be mutually equal, breaking createCopyWithNonEqualValue().
+        assertNotEquals(first, second);
+        assertNotEquals(first.hashCode(), second.hashCode());
+        assertEquals(first, first);
+    }
+
+    @Test
     void shouldNotHandleInvalidTypes() {
         assertFalse(getGeneratorForType(null).isPresent());
         assertFalse(getGeneratorForType(PropertyMemberInfo.class).isPresent());


### PR DESCRIPTION
Implements **PR-3** of `doc/review-26-07-04.md` — generator subsystem correctness.

## Correctness
- **`InterfaceProxyGenerator` (H)** — removed the shared `static DEFAULT_HANDLER`; `next()` now creates a fresh `DefaultInvocationHandler` per call, so proxies of the same interface are no longer mutually `equals` (which had exhausted `createCopyWithNonEqualValue()`'s retry guard). Added regression test `shouldCreateNonEqualProxiesOnSubsequentNextCalls`.
- **`TypedGeneratorRegistry` (M)** — replaced the non-atomic check-then-act (`containsKey`+`get`) with `Optional.ofNullable(REGISTRY.get(type))`.
- **Mutually-recursive types (M)** — `GeneratorResolver` now tracks in-progress types in a `ThreadLocal<Set<Class<?>>>` and returns a `DummyGenerator` on re-entry, preventing `StackOverflowError` for A↔B type cycles (cleaned up in `finally`).

## Robustness & docs
- `ConstructorBasedGenerator`: last-resort loop continues on `Optional.empty()`; `logUsedValuesForConstructor` null-guards each param.
- `DynamicProxyGenerator`: guards `final` (unproxyable) classes → `Optional.empty()`, catches javassist `RuntimeException`, removes the dead `setFilter`.
- `ArraysGenerator` `@param` and `GeneratorResolver` `@return` wording corrected.

`./mvnw clean verify` green on Java 21 (267 tests, +1 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvApYPbcUCtBHU9hxsm8R4)_