### PR TITLE
fix(mapper): register generator extensions and correct MapperTest API [PR-5]

### DIFF
--- a/src/main/java/de/cuioss/test/valueobjects/MapperTest.java
+++ b/src/main/java/de/cuioss/test/valueobjects/MapperTest.java
@@ -16,12 +16,14 @@
 package de.cuioss.test.valueobjects;
 
 import de.cuioss.test.generator.TypedGenerator;
+import de.cuioss.test.generator.junit.GeneratorControllerExtension;
 import de.cuioss.test.valueobjects.api.VerifyMapperConfiguration;
 import de.cuioss.test.valueobjects.api.property.PropertyConfig;
 import de.cuioss.test.valueobjects.api.property.PropertyConfigs;
 import de.cuioss.test.valueobjects.api.property.PropertyReflectionConfig;
 import de.cuioss.test.valueobjects.contract.MapperContractImpl;
 import de.cuioss.test.valueobjects.generator.dynamic.GeneratorResolver;
+import de.cuioss.test.valueobjects.junit5.extension.GeneratorRegistryController;
 import de.cuioss.test.valueobjects.objects.ParameterizedInstantiator;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.test.valueobjects.objects.TestObjectProvider;
@@ -36,14 +38,23 @@ import de.cuioss.tools.reflect.MoreReflection;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.function.Function;
 
-import static de.cuioss.test.valueobjects.util.ReflectionHelper.*;
+import static de.cuioss.test.valueobjects.util.ReflectionHelper.handlePostProcessConfig;
+import static de.cuioss.test.valueobjects.util.ReflectionHelper.handlePropertyMetadata;
+import static de.cuioss.test.valueobjects.util.ReflectionHelper.scanBeanTypeForProperties;
+import static de.cuioss.test.valueobjects.util.ReflectionHelper.shouldScanClass;
 import static de.cuioss.tools.collect.CollectionLiterals.immutableList;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Allows to test a mapper implementing a {@link Function} to map a (pseudo-)DTO
@@ -80,6 +91,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @param <T> Target: The type of the source-Objects to be mapped to
  */
 @SuppressWarnings("squid:S2187") // Base class for tests
+@ExtendWith({GeneratorControllerExtension.class, GeneratorRegistryController.class})
 public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegistry, TestObjectProvider<M> {
 
     @Getter(AccessLevel.PROTECTED)
@@ -97,24 +109,31 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
      * once
      */
     @SuppressWarnings({"unchecked"})
-    protected void intializeTypeInformation() {
+    protected void initializeTypeInformation() {
         if (null == mapperClass) {
             var parameterized = MoreReflection.extractParameterizedType(getClass()).orElseThrow(
-                () -> new IllegalArgumentException("Given type defines no generic Type: " + getClass()));
+                () -> new AssertionError("Given type defines no generic Type: " + getClass()));
             List<Type> types = immutableList(parameterized.getActualTypeArguments());
             Preconditions.checkArgument(3 == types.size(), "Super Class must provide 3 generic types in order to work");
             mapperClass = (Class<M>) MoreReflection.extractGenericTypeCovariantly(types.getFirst())
-                .orElseThrow(() -> new AssertionError("Unable to determine mapperClass from type" + getClass()));
-            assertNotNull(mapperClass, "Unable to determine mapperClass");
+                .orElseThrow(() -> new AssertionError("Unable to determine mapperClass from type " + getClass()));
             assertFalse(mapperClass.isInterface(),
                 "This type only works with concrete implementations, but was the interface " + mapperClass);
             sourceClass = (Class<S>) MoreReflection.extractGenericTypeCovariantly(types.get(1))
-                .orElseThrow(() -> new AssertionError("Unable to determine sourceClass from type" + getClass()));
-            assertNotNull(sourceClass, "Unable to determine sourceClass");
+                .orElseThrow(() -> new AssertionError("Unable to determine sourceClass from type " + getClass()));
             targetClass = (Class<T>) MoreReflection.extractGenericTypeCovariantly(types.get(2))
-                .orElseThrow(() -> new AssertionError("Unable to determine targetClass from type" + getClass()));
-            assertNotNull(targetClass, "Unable to determine targetClass");
+                .orElseThrow(() -> new AssertionError("Unable to determine targetClass from type " + getClass()));
         }
+    }
+
+    /**
+     * @deprecated misspelled method name, use {@link #initializeTypeInformation()}
+     *             instead. Retained for backwards compatibility with subclasses and
+     *             tests that call it directly.
+     */
+    @Deprecated
+    protected void intializeTypeInformation() {
+        initializeTypeInformation();
     }
 
     /**
@@ -132,7 +151,7 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
      * @param targetConfig providing configuration, may be null
      */
     public void verifyMapper(PropertyReflectionConfig targetConfig) {
-        intializeTypeInformation();
+        initializeTypeInformation();
         Optional<VerifyMapperConfiguration> config = MoreReflection.extractAnnotation(getClass(),
             VerifyMapperConfiguration.class);
 
@@ -153,7 +172,7 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
 
     @Override
     public M getUnderTest() {
-        intializeTypeInformation();
+        initializeTypeInformation();
         return new DefaultInstantiator<>(mapperClass).newInstance();
     }
 
@@ -166,7 +185,7 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
      *         the configured attributes
      */
     public List<PropertyMetadata> resolveSourcePropertyMetadata() {
-        intializeTypeInformation();
+        initializeTypeInformation();
         return handlePropertyMetadata(getClass(), getSourceClass());
     }
 
@@ -180,11 +199,11 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
      *         the configured attributes
      */
     public List<PropertyMetadata> resolveTargetPropertyMetadata(PropertyReflectionConfig config) {
-        intializeTypeInformation();
+        initializeTypeInformation();
         final List<PropertyMetadata> builder = new ArrayList<>();
-        if (shouldScanClass(getClass())) {
+        if (shouldScanClass(config)) {
             final SortedSet<PropertyMetadata> scanned = new TreeSet<>(
-                scanBeanTypeForProperties(anyTargetObject().getClass(), config));
+                scanBeanTypeForProperties(targetClass, config));
             builder.addAll(handlePostProcessConfig(config, scanned));
         }
         final var handled = PropertyHelper.handlePrimitiveAsDefaults(PropertyHelper.toMapView(builder).values());
@@ -200,7 +219,7 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
      *         {@link TypedGenerator}, see {@link GeneratorRegistry}
      */
     public T anyTargetObject() {
-        intializeTypeInformation();
+        initializeTypeInformation();
         return GeneratorResolver.resolveGenerator(targetClass).next();
     }
 
@@ -213,7 +232,7 @@ public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegi
      */
     @SuppressWarnings("java:S1452") // owolff: using wildcards here is the only way
     public ParameterizedInstantiator<? extends S> getSourceInstantiator(RuntimeProperties runtimeProperties) {
-        intializeTypeInformation();
+        initializeTypeInformation();
         return new BeanInstantiator<>(new DefaultInstantiator<>(getSourceClass()), runtimeProperties);
     }
 }

--- a/src/main/java/de/cuioss/test/valueobjects/PropertyAwareTest.java
+++ b/src/main/java/de/cuioss/test/valueobjects/PropertyAwareTest.java
@@ -24,6 +24,7 @@ import de.cuioss.test.valueobjects.property.PropertyMetadata;
 import de.cuioss.test.valueobjects.util.GeneratorRegistry;
 import de.cuioss.test.valueobjects.util.ReflectionHelper;
 import de.cuioss.tools.reflect.MoreReflection;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,8 +60,18 @@ import java.util.SortedSet;
 @ExtendWith({GeneratorControllerExtension.class, GeneratorRegistryController.class})
 public class PropertyAwareTest<T> implements GeneratorRegistry {
 
+    /**
+     * The runtime class of the generic type {@code T}. It is resolved from the
+     * generic super type in {@link #initializePropertiesAndGenerators()} before
+     * each test. The setter is restricted to {@code protected} on purpose: the
+     * value is (re)computed and overwritten by
+     * {@link #initializePropertiesAndGenerators()} on every test invocation, so
+     * overwriting it externally would desync from the resolved
+     * {@link #propertyMetadata}. It is exposed to subclasses only for the rare
+     * cases where the generic type can not be derived by reflection.
+     */
     @Getter
-    @Setter
+    @Setter(AccessLevel.PROTECTED)
     private Class<T> targetBeanClass;
 
     @Getter

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @VerifyMapperConfiguration(equals = {"firstname:nameFirst", "lastname:nameLast", "attributeList:listOfAttributes"})
 class BaseMapperTestTest extends MapperTest<SimpleMapper, SimpleSourceBean, SimpleTargetBean> {
@@ -46,6 +48,30 @@ class BaseMapperTestTest extends MapperTest<SimpleMapper, SimpleSourceBean, Simp
     void shouldDetermineTargetMetadata() {
         assertNotNull(super.resolveTargetPropertyMetadata(null));
         assertEquals(3, super.resolveTargetPropertyMetadata(null).size());
+    }
+
+    @Test
+    void shouldProvideAnyTargetObject() {
+        var target = super.anyTargetObject();
+        assertNotNull(target);
+        assertEquals(SimpleTargetBean.class, target.getClass());
+    }
+
+    @Test
+    void shouldFailForMissingGenericType() {
+        var error = assertThrows(AssertionError.class, new RawMapper()::triggerTypeInformation);
+        assertTrue(error.getMessage().contains("no generic Type"), error.getMessage());
+    }
+
+    /**
+     * Raw (non-parameterized) subclass used to exercise the guard that fails when
+     * the generic type arguments of {@link MapperTest} can not be resolved.
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    static class RawMapper extends MapperTest {
+        void triggerTypeInformation() {
+            initializeTypeInformation();
+        }
     }
 
 }


### PR DESCRIPTION
Implements **PR-5** of `doc/review-26-07-04.md` — MapperTest correctness & API.

## Correctness
- **`MapperTest` (H)** — added `@ExtendWith({GeneratorControllerExtension.class, GeneratorRegistryController.class})` (matching `PropertyAwareTest`), so `@PropertyGenerator` / `registerBasicTypes()` actually run for mapper tests instead of silently never firing. Registration is idempotent, so the existing hand-wired `@BeforeEach` compensation in the project's mapper test still passes.
- **`verifyMapper` target scanning (M)** — gate target-metadata scanning on the `config` param (not the class-level `@PropertyReflectionConfig`, which documents the *source*), so a `skip=true` source config no longer empties target metadata.
- **Target scan source (M)** — scan `targetClass` directly instead of `anyTargetObject().getClass()` (no full object generated just for its class).

## API & cleanup
- Added correctly-spelled `initializeTypeInformation()`; kept the misspelled `intializeTypeInformation()` as a `@Deprecated` delegate.
- Removed three dead `assertNotNull` calls after `orElseThrow`; standardized exception types + message spacing; expanded wildcard imports to explicit.
- `PropertyAwareTest`: `setTargetBeanClass()` restricted to `@Setter(AccessLevel.PROTECTED)` with a doc note on the desync hazard.

`./mvnw clean verify` green on Java 21 (266 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvApYPbcUCtBHU9hxsm8R4)_