### PR TITLE
fix(property): correct property/reflection/collection-assert logic [PR-4]

### DIFF
--- a/src/main/java/de/cuioss/test/valueobjects/property/PropertySupport.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/PropertySupport.java
@@ -21,6 +21,8 @@ import de.cuioss.test.valueobjects.property.util.CollectionAsserts;
 import de.cuioss.test.valueobjects.property.util.PropertyAccessStrategy;
 import lombok.*;
 
+import java.util.Objects;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -141,6 +143,12 @@ public class PropertySupport {
 
         if (AssertionStrategy.COLLECTION_IGNORE_ORDER.equals(propertyMetadata.getAssertionStrategy())) {
             CollectionAsserts.assertListsAreEqualIgnoringOrder(propertyMetadata.getName(), expected, actual);
+        } else if (null != expected && expected.getClass().isArray()) {
+            // arrays only provide reference equality via equals, therefore compare by
+            // value. Objects.deepEquals handles Object[] as well as all primitive array
+            // types, including nested arrays.
+            assertTrue(Objects.deepEquals(expected, actual), "Invalid content found for property "
+                + propertyMetadata.getName() + ", expected=" + expected + ", actual=" + actual);
         } else {
             assertEquals(expected, actual, "Invalid content found for property " + propertyMetadata.getName()
                 + ", expected=" + expected + ", actual=" + actual);
@@ -152,7 +160,7 @@ public class PropertySupport {
      * Reads and returns the read property from the given target
      *
      * @param target to be read from, must not be null
-     * @return he read Property, may be {@code null}
+     * @return the read property, may be {@code null}
      */
     public Object readProperty(Object target) {
         assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
@@ -164,7 +172,8 @@ public class PropertySupport {
      *
      * @param target        to be written to, must not be null
      * @param propertyValue to be written
-     * @return he read Property, may be {@code null}
+     * @return the modified target object as returned by the configured
+     *         {@link PropertyAccessStrategy}, may be {@code null}
      */
     public Object writeProperty(Object target, Object propertyValue) {
         assertNotNull(target, TARGET_MUST_NOT_BE_NULL);

--- a/src/main/java/de/cuioss/test/valueobjects/property/impl/PropertyMetadataImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/impl/PropertyMetadataImpl.java
@@ -270,6 +270,20 @@ public class PropertyMetadataImpl implements PropertyMetadata {
         return builder;
     }
 
+    /**
+     * The natural ordering is defined solely by the property {@link #getName()
+     * name}. This is intentional: within a given bean a property name is unique,
+     * therefore ordering (and the resulting {@link java.util.SortedSet}
+     * de-duplication) by name is the desired behaviour and prevents
+     * differently-configured metadata for the <em>same</em> property name from
+     * co-existing in a single property set.
+     * <p>
+     * As a consequence the natural ordering is deliberately <em>inconsistent with
+     * equals</em> (see {@link Comparable}): the Lombok-generated
+     * {@link #equals(Object)} compares all fields (except the generator), whereas
+     * {@code compareTo} only considers the name. Callers relying on full-field
+     * equality must not depend on {@code compareTo == 0} implying {@code equals}.
+     */
     @Override
     public int compareTo(final PropertyMetadata other) {
         return name.compareTo(other.getName());

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/CollectionAsserts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/CollectionAsserts.java
@@ -18,6 +18,8 @@ package de.cuioss.test.valueobjects.property.util;
 import lombok.experimental.UtilityClass;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Helper class for asserts on Collection level
@@ -38,8 +40,9 @@ public final class CollectionAsserts {
      *
      * @param propertyName the name of the property, used for creating the
      *                     error-message, must not be null
-     * @param expected
-     * @param actual
+     * @param expected     the expected collection content, may be {@code null}
+     * @param actual       the actual collection content to be compared against
+     *                     {@code expected}, may be {@code null}
      */
     public static void assertListsAreEqualIgnoringOrder(final String propertyName, final Object expected,
         final Object actual) {
@@ -51,7 +54,7 @@ public final class CollectionAsserts {
         if (expected == null || actual == null) {
             fail(NOT_EQUAL, propertyName, expected, actual);
         } else {
-            if (!(expected instanceof Iterable) || !(actual instanceof Iterable)) {
+            if (!(expected instanceof Collection) || !(actual instanceof Collection)) {
                 fail(NO_COLLECTION, propertyName, expected, actual);
             }
             handleAssert(propertyName, expected, actual);
@@ -59,25 +62,28 @@ public final class CollectionAsserts {
     }
 
     private static void handleAssert(final String propertyName, final Object expected, final Object actual) {
-        final Collection<?> expectedIterable = (Collection<?>) expected;
-        final Collection<?> actualIterable = (Collection<?>) actual;
+        final Collection<?> expectedCollection = (Collection<?>) expected;
+        final Collection<?> actualCollection = (Collection<?>) actual;
 
-        if (expectedIterable.size() != actualIterable.size()) {
+        if (expectedCollection.size() != actualCollection.size()) {
             fail(DIFFERENT_SIZES, propertyName, expected, actual);
         }
-        if (expectedIterable.isEmpty()) {
+        if (expectedCollection.isEmpty()) {
             return;
         }
-        for (final Object object : expectedIterable) {
-            if (!actualIterable.contains(object)) {
-                fail(NOT_EQUAL, propertyName, expected, actual);
-            }
+        // Compare element frequencies so that multiplicity is respected, e.g.
+        // [a, a, b] must not be treated as equal to [a, b, b].
+        if (!frequencyMap(expectedCollection).equals(frequencyMap(actualCollection))) {
+            fail(NOT_EQUAL, propertyName, expected, actual);
         }
-        for (final Object object : actualIterable) {
-            if (!expectedIterable.contains(object)) {
-                fail(NOT_EQUAL, propertyName, expected, actual);
-            }
+    }
+
+    private static Map<Object, Long> frequencyMap(final Collection<?> collection) {
+        final Map<Object, Long> counts = new HashMap<>();
+        for (final Object element : collection) {
+            counts.merge(element, 1L, Long::sum);
         }
+        return counts;
     }
 
     private static void fail(final String template, final String propertyName, final Object expected,

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/PropertyAccessStrategy.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/PropertyAccessStrategy.java
@@ -51,7 +51,7 @@ public enum PropertyAccessStrategy {
         public Object writeProperty(final Object target, final PropertyMetadata propertyMetadata,
             final Object propertyValue) {
             assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
-            assertNotNull(target, PROPERTY_METADATA_MUST_NOT_BE_NULL);
+            assertNotNull(propertyMetadata, PROPERTY_METADATA_MUST_NOT_BE_NULL);
             try {
                 PropertyUtil.setProperty(target, propertyMetadata.getName(), propertyValue);
                 return target;
@@ -65,7 +65,7 @@ public enum PropertyAccessStrategy {
         @Override
         public Object readProperty(final Object target, final PropertyMetadata propertyMetadata) {
             assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
-            assertNotNull(target, PROPERTY_METADATA_MUST_NOT_BE_NULL);
+            assertNotNull(propertyMetadata, PROPERTY_METADATA_MUST_NOT_BE_NULL);
             try {
                 return PropertyUtil.readProperty(target, propertyMetadata.getName());
             } catch (IllegalArgumentException | IllegalStateException e) {

--- a/src/main/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelper.java
@@ -85,9 +85,9 @@ public class DeepCopyTestHelper {
                 var resultCopy = accessMethod.invoke(copy);
 
                 // check for null
-                // No sense in checking Strings, primitives and enums
+                // No sense in checking Strings, primitive-wrappers and enums
                 if (!checkNullContract(resultSource, resultCopy, currentPropertyString, propertyName)
-                    || resultSource.getClass().isPrimitive() || resultSource.getClass().isEnum()
+                    || isPrimitiveWrapper(resultSource.getClass()) || resultSource.getClass().isEnum()
                     || String.class.equals(resultSource.getClass())) {
                     continue;
                 }
@@ -103,7 +103,7 @@ public class DeepCopyTestHelper {
                         Collections.emptyList());
                 }
             } catch (IllegalAccessException | InvocationTargetException e) {
-                fail("invoke method " + accessMethod.getName() + "failed: "
+                fail("invoke method " + accessMethod.getName() + " failed: "
                     + ExceptionHelper.extractCauseMessageFromThrowable(e));
             }
 
@@ -131,12 +131,22 @@ public class DeepCopyTestHelper {
         if (!(resultSource instanceof List<?> resultSourceList)) {
             return false;
         }
+        assertInstanceOf(List.class, resultCopy, "property " + currentPropertyString + propertyName
+            + " is a List on the source but not on the copy: " + resultCopy);
+        final var resultCopyList = (List<?>) resultCopy;
+        assertEquals(resultSourceList.size(), resultCopyList.size(), "property " + currentPropertyString + propertyName
+            + " differs in size: " + resultSourceList.size() + " != " + resultCopyList.size());
         for (var i = 0; i < resultSourceList.size(); i++) {
-            testDeepCopy(resultSourceList.get(i), ((List<?>) resultCopy).get(i),
+            testDeepCopy(resultSourceList.get(i), resultCopyList.get(i),
                 currentPropertyString + propertyName + "[" + i + "]", Collections.emptyList());
         }
         return true;
 
+    }
+
+    private static boolean isPrimitiveWrapper(Class<?> type) {
+        return Boolean.class == type || Byte.class == type || Character.class == type || Short.class == type
+            || Integer.class == type || Long.class == type || Float.class == type || Double.class == type;
     }
 
     private static String determinePropertyString(String propertyString) {

--- a/src/main/java/de/cuioss/test/valueobjects/util/ReflectionHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/ReflectionHelper.java
@@ -189,8 +189,7 @@ public final class ReflectionHelper {
                 if (CollectionType.ARRAY_MARKER.equals(collectionType)) {
                     propertyType = field.get().getType().getComponentType();
                 } else {
-                    propertyType = extractParameterizedType(field.get(),
-                        (ParameterizedType) field.get().getGenericType());
+                    propertyType = extractParameterizedType(field.get());
                 }
             }
         }
@@ -208,17 +207,26 @@ public final class ReflectionHelper {
             .generator(GeneratorResolver.resolveGenerator(propertyType)).build();
     }
 
-    private static Class<?> extractParameterizedType(final Field field, final ParameterizedType parameterizedType) {
+    private static Class<?> extractParameterizedType(final Field field) {
+        final var genericType = field.getGenericType();
+        if (!(genericType instanceof ParameterizedType parameterizedType)) {
+            // raw (non-generic) collection field, e.g. 'private List names;'
+            throw unableToDetermineGenericType(field, null);
+        }
         try {
             return (Class<?>) parameterizedType.getActualTypeArguments()[0];
         } catch (final ClassCastException e) {
-            throw new IllegalStateException("""
-                Unable to determine generic-type for %s, ususally this is the case with nested generics. \
-
-                You need to provide a custom @PropertyConfig for this field and exclude it from scanning\
-                , by using PropertyReflectionConfig#exclude.
-                See package-javadoc of de.cuioss.test.valueobjects for samples.""".formatted(field.toString()), e);
+            throw unableToDetermineGenericType(field, e);
         }
+    }
+
+    private static IllegalStateException unableToDetermineGenericType(final Field field, final Throwable cause) {
+        return new IllegalStateException("""
+            Unable to determine generic-type for %s, ususally this is the case with nested generics. \
+
+            You need to provide a custom @PropertyConfig for this field and exclude it from scanning\
+            , by using PropertyReflectionConfig#exclude.
+            See package-javadoc of de.cuioss.test.valueobjects for samples.""".formatted(field.toString()), cause);
     }
 
     /**

--- a/src/test/java/de/cuioss/test/valueobjects/property/PropertySupportTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/PropertySupportTest.java
@@ -24,9 +24,12 @@ import de.cuioss.test.valueobjects.api.property.PropertyConfig;
 import de.cuioss.test.valueobjects.api.property.PropertyReflectionConfig;
 import de.cuioss.test.valueobjects.objects.impl.DefaultInstantiator;
 import de.cuioss.test.valueobjects.property.impl.PropertyMetadataImpl;
+import de.cuioss.test.valueobjects.property.util.CollectionType;
 import de.cuioss.test.valueobjects.testbeans.ComplexBean;
+import de.cuioss.test.valueobjects.testbeans.beanproperty.BeanWithDefensiveArrayCopy;
 import org.junit.jupiter.api.Test;
 
+import static de.cuioss.test.generator.Generators.nonEmptyStrings;
 import static de.cuioss.test.valueobjects.generator.JavaTypesGenerator.BOOLEANS;
 import static de.cuioss.test.valueobjects.generator.JavaTypesGenerator.STRINGS;
 import static de.cuioss.test.valueobjects.testbeans.ComplexBean.*;
@@ -98,6 +101,31 @@ class PropertySupportTest extends ValueObjectTest<PropertySupport> {
         // Revert Boolean
         target.setBooleanPrimitive(!target.isBooleanPrimitive());
         assertThrows(AssertionError.class, () -> propertySupport.assertValueSet(target));
+    }
+
+    @Test
+    void shouldCompareArrayPropertiesByValue() {
+        final PropertyMetadata arrayProperty = PropertyMetadataImpl.builder().name("array")
+            .generator(nonEmptyStrings()).collectionType(CollectionType.ARRAY_MARKER).build();
+        final var propertySupport = new PropertySupport(arrayProperty);
+        final var target = new BeanWithDefensiveArrayCopy();
+        final var expected = new String[]{"a", "b", "c"};
+        target.setArray(expected);
+        // the getter returns a defensive copy, therefore the value is equal but not
+        // reference-identical -> only value based comparison can succeed
+        assertNotSame(expected, target.getArray());
+        propertySupport.assertValueSet(target, expected);
+    }
+
+    @Test
+    void shouldDetectDifferingArrayContent() {
+        final PropertyMetadata arrayProperty = PropertyMetadataImpl.builder().name("array")
+            .generator(nonEmptyStrings()).collectionType(CollectionType.ARRAY_MARKER).build();
+        final var propertySupport = new PropertySupport(arrayProperty);
+        final var target = new BeanWithDefensiveArrayCopy();
+        target.setArray(new String[]{"a", "b", "c"});
+        final var wrongExpected = new String[]{"a", "b", "different"};
+        assertThrows(AssertionError.class, () -> propertySupport.assertValueSet(target, wrongExpected));
     }
 
     @Test

--- a/src/test/java/de/cuioss/test/valueobjects/property/util/CollectionAssertsTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/util/CollectionAssertsTest.java
@@ -101,4 +101,14 @@ class CollectionAssertsTest {
         final List<String> list2 = immutableList("a", "b", "c");
         assertThrows(AssertionError.class, () -> assertListsAreEqualIgnoringOrder("propertyName", list2, list1));
     }
+
+    @Test
+    void shouldRespectElementFrequency() {
+        // Same size and same distinct elements, but different multiplicities:
+        // [a, a, b] must NOT be equal-ignoring-order to [a, b, b].
+        final List<String> list1 = immutableList("a", "a", "b");
+        final List<String> list2 = immutableList("a", "b", "b");
+        assertThrows(AssertionError.class, () -> assertListsAreEqualIgnoringOrder("propertyName", list1, list2));
+        assertThrows(AssertionError.class, () -> assertListsAreEqualIgnoringOrder("propertyName", list2, list1));
+    }
 }

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanWithDefensiveArrayCopy.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanWithDefensiveArrayCopy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.valueobjects.testbeans.beanproperty;
+
+/**
+ * A bean with a {@code String[]} property that returns / stores defensive
+ * copies. As a consequence the value read back is equal by <em>value</em> but
+ * never identical by <em>reference</em> to the value written. This is used to
+ * verify that {@code PropertySupport#assertValueSet} compares array typed
+ * properties by value ({@code Objects.deepEquals}) instead of reference.
+ */
+public class BeanWithDefensiveArrayCopy {
+
+    private String[] array;
+
+    public String[] getArray() {
+        return null == array ? null : array.clone();
+    }
+
+    public void setArray(final String[] array) {
+        this.array = null == array ? null : array.clone();
+    }
+}

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithRawCollection.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithRawCollection.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.cuioss.test.valueobjects.testbeans.property;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * Contains a raw (non-generic) {@link List} field. Used to verify that
+ * reflection based property scanning fails with a descriptive
+ * {@link IllegalStateException} because the element type cannot be determined.
+ */
+@SuppressWarnings({"rawtypes", "unused"})
+public class BeanWithRawCollection {
+
+    @Getter
+    private List names;
+}

--- a/src/test/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelperTest.java
@@ -64,6 +64,73 @@ class DeepCopyTestHelperTest {
         assertThrows(AssertionError.class, () -> DeepCopyTestHelper.verifyDeepCopy(a, a));
     }
 
+    @Test
+    void shouldTreatPrimitiveWrappersAsImmutable() {
+        // Wrapper values are immutable, therefore the copy is allowed to share
+        // the (potentially cached) instances with the source. This exercises the
+        // isPrimitiveWrapper short-cut for every wrapper type. Values are chosen
+        // outside the auto-box cache range to make the point that no reference
+        // identity is required.
+        var source = new WrapperBean(Boolean.TRUE, (byte) 100, 'x', (short) 200, 1000, 100_000L, 1.5f, 2.5d);
+        var copy = new WrapperBean(Boolean.TRUE, (byte) 100, 'x', (short) 200, 1000, 100_000L, 1.5f, 2.5d);
+        DeepCopyTestHelper.verifyDeepCopy(source, copy);
+        DeepCopyTestHelper.verifyDeepCopy(copy, source);
+    }
+
+    @Test
+    void shouldFailWhenAccessMethodThrows() {
+        assertThrows(AssertionError.class,
+            () -> DeepCopyTestHelper.verifyDeepCopy(new ThrowingGetterBean(), new ThrowingGetterBean()));
+    }
+
+    static class ThrowingGetterBean {
+
+        @SuppressWarnings("unused") // invoked reflectively by the deep-copy helper
+        public String getValue() {
+            throw new IllegalStateException("boom");
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            return obj instanceof ThrowingGetterBean;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31;
+        }
+    }
+
+    @AllArgsConstructor
+    @ToString
+    @EqualsAndHashCode
+    static class WrapperBean {
+
+        @Getter
+        private final Boolean booleanValue;
+
+        @Getter
+        private final Byte byteValue;
+
+        @Getter
+        private final Character characterValue;
+
+        @Getter
+        private final Short shortValue;
+
+        @Getter
+        private final Integer integerValue;
+
+        @Getter
+        private final Long longValue;
+
+        @Getter
+        private final Float floatValue;
+
+        @Getter
+        private final Double doubleValue;
+    }
+
     @AllArgsConstructor
     @ToString
     @EqualsAndHashCode

--- a/src/test/java/de/cuioss/test/valueobjects/util/ReflectionHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/ReflectionHelperTest.java
@@ -176,6 +176,14 @@ class ReflectionHelperTest {
     }
 
     @Test
+    void shouldFailOnRawCollection() {
+        final var exception = assertThrows(IllegalStateException.class,
+            () -> scanBeanTypeForProperties(BeanWithRawCollection.class, null));
+        assertTrue(exception.getMessage().contains("Unable to determine generic-type"),
+            "Should provide a descriptive message, but was: " + exception.getMessage());
+    }
+
+    @Test
     @SuppressWarnings("java:S2699")
     // owolff not throwing an exception is the actual test
     void shouldSkipNestedGenerics() {


### PR DESCRIPTION
Implements **PR-4** of `doc/review-26-07-04.md` — property, reflection & collection-assert correctness.

## Correctness
- **`CollectionAsserts` "equal ignoring order" (H)** — replaced the two one-way `contains` sweeps (which wrongly treated `[a,a,b]` == `[a,b,b]`) with element-frequency comparison. Added regression test `shouldRespectElementFrequency`.
- **`CollectionAsserts` guard (M)** — guard on `instanceof Collection` (matching the cast) instead of `Iterable`.
- **`PropertyAccessStrategy` (M)** — the copy-pasted second `assertNotNull(target)` now correctly null-checks `propertyMetadata`.
- **`PropertySupport.assertValueSet` (M)** — array-typed properties now compared by value (`Objects.deepEquals`) instead of reference equality, so defensive-copy getters pass.
- **`ReflectionHelper` (M)** — checks `instanceof ParameterizedType` before casting, throwing the descriptive `IllegalStateException` instead of a raw `ClassCastException` for raw collection fields.
- **`PropertyMetadataImpl.compareTo` (M)** — documented the intentional name-based natural ordering (name-based `SortedSet` de-dup is the intended behavior; a name-only `equals` would break the field-mutation equality tests).

## Robustness & docs
- `DeepCopyTestHelper`: `checkForList` asserts `instanceof List` + equal size before indexing; replaced the always-false `isPrimitive()` branch with a real wrapper-type check; fixed a missing-space message.
- Filled empty `@param`/`@return` Javadoc on `CollectionAsserts` and `PropertySupport`.

`./mvnw clean verify` green on Java 21 (267 tests, +1 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvApYPbcUCtBHU9hxsm8R4)_