### PR TITLE
docs: correct CLAUDE.md and AsciiDoc project documentation [PR-7]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,25 +22,13 @@ Always use `./mvnw` (or `./mvnw.cmd` on Windows) instead of `mvn` to ensure cons
 ### Java Version Requirements
 - Primary development: Java 21
 - CI/CD tests against: Java 21 and 25
-- Minimum release target: Configurable via `-Dmaven.compiler.release=<version>`
+- Minimum release target: Configurable via `-Dmaven.compiler-plugin.release=<version>` (the property the parent POM actually reads)
 
 ### Quality and Deployment
 - **SonarCloud analysis**: `./mvnw -B verify -Psonar sonar:sonar` (requires SONAR_TOKEN)
 - **Deploy snapshot**: `./mvnw -B -Prelease-snapshot deploy -Dmaven.test.skip=true`
 - **Generate Javadoc**: `./mvnw -Prelease-snapshot javadoc:aggregate`
 
-
-## Git Workflow
-
-This repository has branch protection on `main`. Direct pushes to `main` are never allowed. Always use this workflow:
-
-1. Create a feature branch: `git checkout -b <branch-name>`
-2. Commit changes: `git add <files> && git commit -m "<message>"`
-3. Push the branch: `git push -u origin <branch-name>`
-4. Create a PR: `gh pr create --head <branch-name> --base main --title "<title>" --body "<body>"`
-5. Enable auto-merge: `gh pr merge --auto --squash --delete-branch`
-6. Wait for merge (check every ~60s): `while gh pr view --json state -q '.state' | grep -q OPEN; do sleep 60; done`
-7. Return to main: `git checkout main && git pull`
 
 ## Architecture Overview
 
@@ -119,7 +107,7 @@ class MyValueObjectTest extends ValueObjectTest<MyValueObject> {
 
 ## Dependencies
 
-Key dependencies defined in parent POM (`cui-java-parent:1.3.3`):
+Key dependencies defined in parent POM (`cui-java-parent`; see the `<parent>` version in `pom.xml`):
 - **JUnit Jupiter**: Test framework (compile scope - this is a testing library)
 - **Lombok**: Annotations for boilerplate reduction
 - **cui-java-tools**: CUI utility library
@@ -149,12 +137,21 @@ Use `@VetoObjectTestContract` to skip specific contracts.
 
 ## CI/CD Pipeline
 
-The project uses GitHub Actions (`.github/workflows/maven.yml`):
-1. **Build job**: Tests against Java 21 and 25
-2. **Sonar-build job**: Runs SonarCloud analysis
-3. **Deploy-snapshot job**: Deploys snapshots to Maven Central (main branch only)
+The project uses GitHub Actions (`.github/workflows/maven.yml`). Rather than defining
+jobs in-repo, the workflow delegates to the organization-wide **reusable workflow**
+`cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml` (pinned by
+commit SHA to a tagged release). The local workflow only:
+- Declares the trigger events (`push` to `main`/`feature|fix|chore|release/*`/`dependabot/**`,
+  `pull_request` against `main`, and `workflow_dispatch`).
+- Passes through the required secrets (`SONAR_TOKEN`, `OSS_SONATYPE_USERNAME`,
+  `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`).
 
-All jobs use Maven wrapper and the Temurin JDK distribution.
+Build behavior (build/test, SonarCloud analysis, snapshot/release deployment, GitHub Pages)
+is configured declaratively via `.github/project.yml` (e.g. `sonar.project-key`,
+`release.*`, `pages.*`, `github-automation.*`) and executed by the reusable workflow.
+To change the JDK matrix, Sonar setup, or deployment steps, update the reusable workflow
+in `cuioss/cuioss-organization` and/or the `.github/project.yml` configuration — not this
+repository's `maven.yml`.
 
 ## Documentation
 

--- a/src/site/asciidoc/managing-metadata.adoc
+++ b/src/site/asciidoc/managing-metadata.adoc
@@ -5,23 +5,25 @@
 In order to work with properties used for link:testing-value-objects.adoc[Value-Object-Testing] the framework provides certain ways to retrieve / define a metadata-model for a concrete value-object. In most cases this is done automatically by using link:reflection-system.adoc[Reflection].
 The resulting metadata is always logged on info-level for eventual debugging / trouble-shooting.
 
-Sample output:
+Sample output (illustrative; taken from an example address bean — the concrete
+generator implementation names and hash suffixes depend on the framework version
+and are not guaranteed to match a current run verbatim):
 
 [listing]
 ----
-INFO: Properties detected by using reflection and PropertyConfig-annotation: 
--'city' (class java.lang.String), QuickCheckGeneratorAdapter(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
--'contentForFormatterSupport' (interface io.cui.util.formatting.template.FormatterSupport), de.cuioss.test.valueobjects.generator.dynamic.impl.InterfaceProxyGenerator@6b19b79, READ_ONLY, BEAN_PROPERTY
--'country' (interface io.cui.cui.common.model.conceptkey.ConceptKeyType), io.cui.ips.namespace.management.facade.service.model.ConceptKeyTypeGenerator@60704c, READ_WRITE, BEAN_PROPERTY
--'empty' (boolean), defaultValued, QuickCheckGeneratorAdapter(type=boolean), READ_ONLY, BEAN_PROPERTY
--'houseNumber' (class java.lang.String), QuickCheckGeneratorAdapter(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
--'id' (class java.lang.String), QuickCheckGeneratorAdapter(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
--'postalCode' (class java.lang.String), QuickCheckGeneratorAdapter(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
--'state' (interface io.cui.cui.common.model.conceptkey.ConceptKeyType), io.cui.ips.namespace.management.facade.service.model.ConceptKeyTypeGenerator@60704c, READ_WRITE, BEAN_PROPERTY
--'streetName' (class java.lang.String), QuickCheckGeneratorAdapter(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
--'type' (class io.cui.service.model.OrganizationAddressType), QuickCheckGeneratorAdapter(type=class io.cui.ips.namespace.management.facade.service.model.OrganizationAddressType), READ_WRITE, BEAN_PROPERTY
--'unstructuredAddress' (class java.lang.String), QuickCheckGeneratorAdapter(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
--'use' (class io.cui.facade.service.model.OrganizationAddressUse), QuickCheckGeneratorAdapter(type=class io.cui..facade.service.model.OrganizationAddressUse), READ_WRITE, BEAN_PROPERTY
+INFO: Properties detected by using reflection and PropertyConfig-annotation:
+-'city' (class java.lang.String), TypedGenerator(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
+-'contentForFormatterSupport' (interface de.cuioss.uimodel.formatting.template.FormatterSupport), de.cuioss.test.valueobjects.generator.dynamic.impl.InterfaceProxyGenerator@6b19b79, READ_ONLY, BEAN_PROPERTY
+-'country' (interface de.cuioss.uimodel.model.conceptkey.ConceptKeyType), de.cuioss.example.service.model.ConceptKeyTypeGenerator@60704c, READ_WRITE, BEAN_PROPERTY
+-'empty' (boolean), defaultValued, TypedGenerator(type=boolean), READ_ONLY, BEAN_PROPERTY
+-'houseNumber' (class java.lang.String), TypedGenerator(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
+-'id' (class java.lang.String), TypedGenerator(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
+-'postalCode' (class java.lang.String), TypedGenerator(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
+-'state' (interface de.cuioss.uimodel.model.conceptkey.ConceptKeyType), de.cuioss.example.service.model.ConceptKeyTypeGenerator@60704c, READ_WRITE, BEAN_PROPERTY
+-'streetName' (class java.lang.String), TypedGenerator(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
+-'type' (class de.cuioss.example.service.model.OrganizationAddressType), TypedGenerator(type=class de.cuioss.example.service.model.OrganizationAddressType), READ_WRITE, BEAN_PROPERTY
+-'unstructuredAddress' (class java.lang.String), TypedGenerator(type=class java.lang.String), READ_WRITE, BEAN_PROPERTY
+-'use' (class de.cuioss.example.service.model.OrganizationAddressUse), TypedGenerator(type=class de.cuioss.example.service.model.OrganizationAddressUse), READ_WRITE, BEAN_PROPERTY
 ----
 
 The precise meta-model is documented by the type `de.cuioss.test.valueobjects.property.PropertyMetadata`

--- a/src/site/asciidoc/reflection-system.adoc
+++ b/src/site/asciidoc/reflection-system.adoc
@@ -2,7 +2,7 @@
 
 === Concepts
 
-The link:managing-metadata.adoc[Metadata-System] for link:testing-value-objects.adoc[Value-Object-Testing] relies heavily on the reflection system. Internally it uses a number of features directly from the JRE, some code inspired by Google Guavas TypeToken, some own tricks, implemented at `cui-java-util` and an internal meta-model, documented at link:managing-metadata.adoc[Managing Metadata].
+The link:managing-metadata.adoc[Metadata-System] for link:testing-value-objects.adoc[Value-Object-Testing] relies heavily on the reflection system. Internally it uses a number of features directly from the JRE, some code inspired by Google Guavas TypeToken, some own tricks, implemented at `cui-java-tools` and an internal meta-model, documented at link:managing-metadata.adoc[Managing Metadata].
 
 === Tweaking the system
 

--- a/src/site/asciidoc/testing-value-objects.adoc
+++ b/src/site/asciidoc/testing-value-objects.adoc
@@ -65,9 +65,36 @@ The annotation `@VerifyConstructor` provides some attributes for fine-tuning the
  class SomeBeanTest extends ValueObjectTest<SomeBean>{...}
 ----
 
-This will test the two distinct factory-methods defined by the type `SomeBean`. The tests will instantiate and check whether the property is available on the created instance. In the case of `required` it will test passing `null` as parameter and expecting an exception to be thrown. In case of an attribute not being required it will as well pass `null` but no exception should occur. 
+This will test the two distinct factory-methods defined by the type `SomeBean`. The tests will instantiate and check whether the property is available on the created instance. In the case of `required` it will test passing `null` as parameter and expecting an exception to be thrown. In case of an attribute not being required it will as well pass `null` but no exception should occur.
 
 The annotation `@VerifyFactoryMethod` provides some attributes for fine-tuning the tests.
+
+==== Testing Copy Constructors
+
+`@VerifyCopyConstructor` verifies a copy-constructor, i.e. a constructor that takes an instance of the same type (or a compatible super-type / interface) and creates a copy of it. It can only be used in combination with at least one other verification contract (e.g. `@VerifyConstructor`, `@VerifyBuilder`), because the framework needs an existing way to create the source instance that is passed to the copy-constructor.
+
+[source,java]
+----
+ @VerifyConstructor(of = "attribute", required = "attribute")
+ @VerifyCopyConstructor
+ class SomeBeanTest extends ValueObjectTest<SomeBean>{...}
+----
+
+For each generated source object the framework calls the copy-constructor and asserts that the individual properties are copied correctly. By default it additionally checks `Object#equals(Object)` between the source and the copy; this can be turned off with `useObjectEquals()`.
+
+The annotation provides several attributes for fine-tuning:
+
+* `of()` / `exclude()`: white-list / black-list of properties (by name) that are considered for the test.
+* `argumentType()`: the declared parameter type of the copy-constructor, if it differs from the type under test (e.g. the constructor accepts an interface or `Serializable` instead of the concrete type).
+* `useObjectEquals()`: whether the copy is additionally compared to the source via `equals` (default `true`).
+* `verifyDeepCopy()`: whether to additionally verify that the copy is a deep copy rather than a shallow one (default `false`). Use `verifyDeepCopyIgnore()` to exclude specific properties from that deep-copy check.
+
+[source,java]
+----
+ @VerifyBuilder
+ @VerifyCopyConstructor(verifyDeepCopy = true, verifyDeepCopyIgnore = "immutableReference")
+ class SomeBeanTest extends ValueObjectTest<SomeBean>{...}
+----
 
 == Canonical Object Methods
 
@@ -91,6 +118,18 @@ This is done by adding the `@VetoObjectTestContract` annotation:
  @VetoObjectTestContract(ObjectTestContracts.TO_STRING)
  class SomeBeanTest extends ValueObjectTest<SomeBean>{...}
 ----
+
+=== Opting in to canonical method testing
+
+`@VetoObjectTestContract` is the right tool when running the full `ValueObjectTest` and you want to exclude a contract. In contrast, `@VerifyObjectTestContract` is the *opt-in* counterpart: it is meant for cases where you do not run all contracts by default but want to explicitly request the canonical object-method checks. When the annotation is present all `ObjectTestContracts` are executed, but you can still veto individual contracts via its `veto()` attribute.
+
+[source,java]
+----
+ @VerifyObjectTestContract(veto = ObjectTestContracts.SERIALIZABLE)
+ class SomeBeanTest extends ValueObjectTest<SomeBean>{...}
+----
+
+The annotation is `@Repeatable`, so multiple declarations can be combined if needed.
 
 === Tweaking Canonical Method Testing
 
@@ -116,7 +155,7 @@ Required properties: -
 Additional properties: country, streetName, city, use, postalCode, houseNumber, id, state, unstructuredAddress, type, contentForFormatterSupport, empty
 Default valued properties: empty
 Writable properties: country, streetName, city, use, postalCode, houseNumber, id, state, unstructuredAddress, type
-Okt 14, 2020 5:38:24 PM de.cuioss.test.valueobjects.contract.EqualsAndHashcodeContractImpl executePropertyTests
+INFO: de.cuioss.test.valueobjects.contract.EqualsAndHashcodeContractImpl executePropertyTests
 INFO: Configured attributes found for equalsAndHashCode-testing: [city, country, houseNumber, id, postalCode, state, streetName, type, unstructuredAddress, use]
 ----
 


### PR DESCRIPTION
Implements **PR-7** of `doc/review-26-07-04.md` — project documentation (no code changes).

- **`CLAUDE.md`**: parent POM version corrected (now points at the real `1.4.5` / pom.xml); CI section rewritten to describe the `cuioss/cuioss-organization` reusable workflow driven by `.github/project.yml` (was falsely describing three in-repo jobs + explicit Temurin matrix); removed the older contradictory Git-Workflow section (kept the "do NOT enable auto-merge" one); documented `-Dmaven.compiler-plugin.release=<version>` (the effective property).
- **`testing-value-objects.adoc`**: added sections for `@VerifyCopyConstructor` and `@VerifyObjectTestContract` (implemented+tested but previously undocumented); refreshed the stale German-locale sample log line.
- **`managing-metadata.adoc`**: refreshed pre-rename `io.cui.*` sample output to `de.cuioss.*` and replaced the defunct `QuickCheckGeneratorAdapter` with a neutral placeholder + an "illustrative" note.
- **`reflection-system.adoc`**: `cui-java-util` → `cui-java-tools`.

`./mvnw verify` green (docs-only; 266 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvApYPbcUCtBHU9hxsm8R4)_