### PR TITLE
fix: replace removed PropertyMemberInfo.NO_IDENTITY in ComplexBean

### DIFF
--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/ComplexBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/ComplexBean.java
@@ -127,7 +127,7 @@ public class ComplexBean implements Serializable {
         metadata.add(STRINGS.metadataBuilder(ATTRIBUTE_TRANSIENT_STRING)
             .propertyMemberInfo(PropertyMemberInfo.TRANSIENT).build());
         metadata.add(STRINGS.metadataBuilder(ATTRIBUTE_NO_OBJECT_IDENTITY_STRING)
-            .propertyMemberInfo(PropertyMemberInfo.NO_IDENTITY).build());
+            .propertyMemberInfo(PropertyMemberInfo.UNDEFINED).build());
         return metadata;
     }
 


### PR DESCRIPTION
## Problem

`main` has been red since **2026-07-07** — 30+ consecutive `Maven Build` failures. Last green run: 2026-07-06.

```
ComplexBean.java:[130,51] cannot find symbol
  symbol:   variable NO_IDENTITY
  location: class de.cuioss.tools.property.PropertyMemberInfo
```

## Root cause

`PropertyMemberInfo.NO_IDENTITY` was removed from `cui-java-tools` in [`645d624`](https://github.com/cuioss/cui-java-tools/commit/645d624) (cuioss/cui-java-tools#202) and released in 2.7.0. That commit describes it as *"removed the never-producible `PropertyMemberInfo.NO_IDENTITY` constant (PROP-7 — verified zero references)"* — the zero-reference check was in-repo only and missed this consumer.

`cui-java-parent` **1.5.0** raised `version.cui.java.tools` 2.6.2 → 2.7.0, which is exactly the commit that turned `main` red here (`chore: update cui-java-parent from 1.4.5 to 1.5.0`, #105). The same parent bump independently broke `cui-portal-ui` and `cui-reference-documentation` in different ways.

The removal was correct on its own terms: `PropertyMemberInfo.resolveForBean` can only ever return `DEFAULT`, `TRANSIENT` or `UNDEFINED`, so the library could never produce `NO_IDENTITY`. An org-wide search finds no other Java consumer, so this repo is adapted rather than the constant restored.

## Why `UNDEFINED`

The only place this framework branches on the value is `EqualsAndHashcodeContractImpl:80`:

```java
.filter(p -> PropertyMemberInfo.DEFAULT.equals(p.getPropertyMemberInfo()))
```

Any non-`DEFAULT` value therefore keeps `noObjectIdentitiyString` out of the equals/hashCode contract — which is precisely what the fixture expresses via Lombok's `@EqualsAndHashCode(exclude = {"noObjectIdentitiyString", ...})`.

`UNDEFINED` is preferred over `TRANSIENT` because:

- the field is **not** transient, so `TRANSIENT` would misdescribe it, and
- the metadata list already contains an `ATTRIBUTE_TRANSIENT_STRING` entry with `TRANSIENT`; reusing it would make the two entries indistinguishable and lose a distinct case.

`completeValidMetadata()` is only ever fed *into* the contracts (`EqualsAndHashcodeContractImpl`, `BeanPropertyContractImpl`, the instantiator tests) — it is never compared against reflection-derived metadata, so nothing asserts on the constant itself.

## Verification

`./mvnw clean verify` locally: **BUILD SUCCESS**, `Tests run: 295, Failures: 0, Errors: 0, Skipped: 0`.

Unblocks #131 and #132, which are `BLOCKED` only because `main` is red.