### PR TITLE
chore: declare inceptionYear 2023 and normalise copyright headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>cui-test-value-objects</artifactId>
     <name>cui value-object testing</name>
     <packaging>jar</packaging>
+    <!-- Must be declared: <inceptionYear> is inherited, and the license plugin binds
+         the copyright ${year} to it. Without this, this project would report
+         cui-parent-pom's 2022 and restamp every header on each -Ppre-commit run. -->
+    <inceptionYear>2023</inceptionYear>
     <version>2.1-SNAPSHOT</version>
     <description>Provides classes and structures for testing java beans,
         builder, constructor, factory-methods,
@@ -30,6 +34,7 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
+        <maven.compiler.release>21</maven.compiler.release>
         <version.javassist>3.32.0-GA</version.javassist>
         <maven.jar.plugin.automatic.module.name>de.cuioss.test.valueobjects</maven.jar.plugin.automatic.module.name>
     </properties>
@@ -65,4 +70,20 @@
             <artifactId>junit-jupiter</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/de/cuioss/test/valueobjects/MapperTest.java
+++ b/src/main/java/de/cuioss/test/valueobjects/MapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,17 +41,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.function.Function;
 
-import static de.cuioss.test.valueobjects.util.ReflectionHelper.handlePostProcessConfig;
-import static de.cuioss.test.valueobjects.util.ReflectionHelper.handlePropertyMetadata;
-import static de.cuioss.test.valueobjects.util.ReflectionHelper.scanBeanTypeForProperties;
-import static de.cuioss.test.valueobjects.util.ReflectionHelper.shouldScanClass;
+import static de.cuioss.test.valueobjects.util.ReflectionHelper.*;
 import static de.cuioss.tools.collect.CollectionLiterals.immutableList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,7 +83,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @param <S> Source: The type of the source-Objects to be mapped from
  * @param <T> Target: The type of the source-Objects to be mapped to
  */
-@SuppressWarnings("squid:S2187") // Base class for tests
+@SuppressWarnings("squid:S2187")
+// Base class for tests
 @ExtendWith({GeneratorControllerExtension.class, GeneratorRegistryController.class})
 public class MapperTest<M extends Function<S, T>, S, T> implements GeneratorRegistry, TestObjectProvider<M> {
 

--- a/src/main/java/de/cuioss/test/valueobjects/PropertyAwareTest.java
+++ b/src/main/java/de/cuioss/test/valueobjects/PropertyAwareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/ValueObjectTest.java
+++ b/src/main/java/de/cuioss/test/valueobjects/ValueObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/ObjectContractTestSupport.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/ObjectContractTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/TestContract.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/TestContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/VerifyMapperConfiguration.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/VerifyMapperConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyBeanProperty.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyBeanProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyBuilder.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyConstructor.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyConstructors.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyConstructors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyCopyConstructor.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyFactoryMethod.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyFactoryMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyFactoryMethods.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/VerifyFactoryMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/contracts/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/contracts/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGeneratorHint.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGeneratorHint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGeneratorHints.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGeneratorHints.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGenerators.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/generator/PropertyGenerators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/generator/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/generator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/ObjectTestConfig.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/ObjectTestConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/ObjectTestContract.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/ObjectTestContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/ObjectTestContracts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/ObjectTestContracts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/VerifyObjectTestContract.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/VerifyObjectTestContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/VerifyObjectTestContracts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/VerifyObjectTestContracts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/VetoObjectTestContract.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/VetoObjectTestContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/VetoObjectTestContracts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/VetoObjectTestContracts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/VetoType.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/VetoType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/object/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/object/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyBuilderConfig.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyBuilderConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyBuilderConfigs.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyBuilderConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyConfig.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyConfigs.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyReflectionConfig.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/property/PropertyReflectionConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/api/property/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/api/property/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/BeanPropertyContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/BeanPropertyContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/BuilderContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/BuilderContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/ContractRegistry.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/ContractRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public class CopyConstructorContractImpl<T> implements TestContract<T> {
             LOGGER.debug("Not checking deep-copy, disabled by configuration");
             return;
         }
-        LOGGER.info("Verifying deep-copy, ignoring properties: {}", verifyDeepCopyIgnore);
+        LOGGER.info("Verifying deep-copy, ignoring properties: %s", verifyDeepCopyIgnore);
 
         final var all = instantiator.getRuntimeProperties().getAllAsPropertySupport(true);
 

--- a/src/main/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,7 +306,7 @@ public class EqualsAndHashcodeContractImpl implements ObjectTestContract {
         final var msgNotEqualsObject = "Expected result for equals(new Object()) will be 'false'. Class was : "
             + underTest.getClass();
 
-        assertFalse(underTest.equals(new Object()), msgNotEqualsObject);
+        assertNotEquals(underTest, new Object(), msgNotEqualsObject);
 
         final var msgEqualsToSelf = "Expected result for equals(underTest) will be 'true'. Class was : "
             + underTest.getClass();

--- a/src/main/java/de/cuioss/test/valueobjects/contract/MapperContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/MapperContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/ObjectCreatorContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/ObjectCreatorContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/ReflectionUtil.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/ReflectionUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/SerializableContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/SerializableContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/ToStringContractImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/ToStringContractImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/support/AssertTuple.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/support/AssertTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/support/MapperAttributesAsserts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/support/MapperAttributesAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/support/MappingAssertStrategy.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/support/MappingAssertStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,18 +34,18 @@ import static org.junit.jupiter.api.Assertions.*;
 enum MappingAssertStrategy {
 
     EQUALS {
-        @Override
-        public void assertMapping(PropertySupport sourceProperty, Object sourceObject, PropertySupport targetProperty,
-            Object targetObject) {
-            targetProperty.assertValueSet(targetObject, sourceProperty.readProperty(sourceObject));
-        }
+    @Override
+    public void assertMapping(PropertySupport sourceProperty, Object sourceObject, PropertySupport targetProperty,
+        Object targetObject) {
+        targetProperty.assertValueSet(targetObject, sourceProperty.readProperty(sourceObject));
+    }
 
-        @Override
-        public List<MappingTuple> readConfiguration(VerifyMapperConfiguration config) {
-            return mutableList(config.equals()).stream().map(mapping -> new MappingTuple(mapping, this)).toList();
-        }
+    @Override
+    public List<MappingTuple> readConfiguration(VerifyMapperConfiguration config) {
+        return mutableList(config.equals()).stream().map(mapping -> new MappingTuple(mapping, this)).toList();
+    }
 
-    },
+},
     NOT_NULL {
         @Override
         public void assertMapping(PropertySupport sourceProperty, Object sourceObject, PropertySupport targetProperty,

--- a/src/main/java/de/cuioss/test/valueobjects/contract/support/MappingTuple.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/support/MappingTuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/contract/support/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/contract/support/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/JavaTypesGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/JavaTypesGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,10 @@ import java.io.Serializable;
 import java.net.URL;
 import java.time.*;
 import java.time.temporal.Temporal;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 import static de.cuioss.test.generator.Generators.*;
 import static de.cuioss.tools.base.Preconditions.checkArgument;

--- a/src/main/java/de/cuioss/test/valueobjects/generator/TypedGeneratorRegistry.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/TypedGeneratorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/DynamicTypedGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/DynamicTypedGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolver.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,11 +25,7 @@ import de.cuioss.tools.logging.CuiLogger;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ArraysGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ArraysGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/CollectionTypeGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/CollectionTypeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DefaultInvocationHandler.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DefaultInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,9 @@ public class DynamicProxyGenerator<T> implements TypedGenerator<T> {
             final var proxyFactory = new ProxyFactory();
             proxyFactory.setSuperclass(type);
             createClassType = proxyFactory.createClass();
-        } catch (final RuntimeException e) {
+        }
+        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+        catch (final RuntimeException e) {
             LOGGER.warn(e, "Unable to create javassist proxy for type %s", type);
             return Optional.empty();
         }

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/EmptyMapGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/EmptyMapGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/dynamic/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/impl/DummyGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/impl/DummyGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/impl/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/generator/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/generator/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/EnableGeneratorRegistry.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/EnableGeneratorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldBeNotNull.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldBeNotNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldBeSerializable.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldBeSerializable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldHandleObjectContracts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldHandleObjectContracts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldImplementEqualsAndHashCode.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldImplementEqualsAndHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldImplementToString.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldImplementToString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/contracts/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/extension/GeneratorRegistryController.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/extension/GeneratorRegistryController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/extension/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/extension/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/junit5/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/junit5/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/BuilderInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/BuilderInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/ConfigurationCallBackHandler.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/ConfigurationCallBackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/ObjectInstantiationException.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/ObjectInstantiationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/ObjectInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/ObjectInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/ParameterizedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/ParameterizedInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/RuntimeProperties.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/RuntimeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/TestObjectProvider.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/TestObjectProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractInlineInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractInlineInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractOrderedArgsInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/AbstractOrderedArgsInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BeanInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BeanInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderConstructorBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderConstructorBasedInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,9 @@ public class BuilderConstructorBasedInstantiator<T> implements BuilderInstantiat
     public T build(final Object builder) {
         try {
             return (T) builderMethod.invoke(builder);
-        } catch (IllegalAccessException | InvocationTargetException | RuntimeException e) {
+        }
+        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+        catch (IllegalAccessException | InvocationTargetException | RuntimeException e) {
             throw new ObjectInstantiationException("Unable to access method " + builderMethod.getName() + " on type "
                 + getBuilderClass().getName() + ", due to " + extractCauseMessageFromThrowable(e), e);
         }

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderFactoryBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderFactoryBasedInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,9 @@ public class BuilderFactoryBasedInstantiator<T> implements BuilderInstantiator<T
     public T build(final Object builder) {
         try {
             return (T) builderMethod.invoke(builder);
-        } catch (IllegalAccessException | InvocationTargetException | RuntimeException e) {
+        }
+        /*TODO: Catch specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe*/
+        catch (IllegalAccessException | InvocationTargetException | RuntimeException e) {
             final var message = UNABLE_TO_ACCESS_METHOD.formatted(builderMethod.getName(), builderClass.getName(),
                 extractCauseMessageFromThrowable(e));
             LOGGER.debug(message, e);

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderParameterizedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/BuilderParameterizedInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/CallbackAwareInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/CallbackAwareInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/ConstructorBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/ConstructorBasedInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/DefaultInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/DefaultInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/ExceptionHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/ExceptionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/FactoryBasedInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/FactoryBasedInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/InjectedBeanInstantiator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/InjectedBeanInstantiator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/InstantiatorConstants.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/InstantiatorConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/impl/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/objects/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/objects/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/PropertyMetadata.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/PropertyMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/PropertySupport.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/PropertySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/impl/BuilderMetadata.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/impl/BuilderMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/impl/PropertyMetadataImpl.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/impl/PropertyMetadataImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/impl/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/AssertionStrategy.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/AssertionStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/CollectionAsserts.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/CollectionAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/CollectionType.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/CollectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,22 +36,22 @@ public enum CollectionType {
 
     /** Represents a {@link Collection}. The implementation will return a list. */
     COLLECTION(Collection.class) {
-        @Override
-        public Iterable<?> nextIterable(final CollectionGenerator<?> collectionGenerator) {
-            return collectionGenerator.list();
-        }
+    @Override
+    public Iterable<?> nextIterable(final CollectionGenerator<?> collectionGenerator) {
+        return collectionGenerator.list();
+    }
 
-        @Override
-        public Iterable<?> wrapToIterable(final Iterable<?> iterable) {
-            return mutableList(iterable);
-        }
+    @Override
+    public Iterable<?> wrapToIterable(final Iterable<?> iterable) {
+        return mutableList(iterable);
+    }
 
-        @Override
-        public Iterable<?> emptyCollection() {
-            return immutableList();
-        }
+    @Override
+    public Iterable<?> emptyCollection() {
+        return immutableList();
+    }
 
-    },
+},
     /** Represents a {@link List}. */
     LIST(List.class) {
         @Override

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/PropertyAccessStrategy.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/PropertyAccessStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,33 +47,33 @@ public enum PropertyAccessStrategy {
      *
      */
     BEAN_PROPERTY {
-        @Override
-        public Object writeProperty(final Object target, final PropertyMetadata propertyMetadata,
-            final Object propertyValue) {
-            assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
-            assertNotNull(propertyMetadata, PROPERTY_METADATA_MUST_NOT_BE_NULL);
-            try {
-                PropertyUtil.setProperty(target, propertyMetadata.getName(), propertyValue);
-                return target;
-            } catch (IllegalArgumentException | IllegalStateException e) {
-                throw new AssertionError(UNABLE_TO_SET_PROPERTY.formatted(propertyMetadata.getName(),
-                    ExceptionHelper.extractCauseMessageFromThrowable(e)), e);
-            }
-
+    @Override
+    public Object writeProperty(final Object target, final PropertyMetadata propertyMetadata,
+        final Object propertyValue) {
+        assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
+        assertNotNull(propertyMetadata, PROPERTY_METADATA_MUST_NOT_BE_NULL);
+        try {
+            PropertyUtil.setProperty(target, propertyMetadata.getName(), propertyValue);
+            return target;
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw new AssertionError(UNABLE_TO_SET_PROPERTY.formatted(propertyMetadata.getName(),
+                ExceptionHelper.extractCauseMessageFromThrowable(e)), e);
         }
 
-        @Override
-        public Object readProperty(final Object target, final PropertyMetadata propertyMetadata) {
-            assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
-            assertNotNull(propertyMetadata, PROPERTY_METADATA_MUST_NOT_BE_NULL);
-            try {
-                return PropertyUtil.readProperty(target, propertyMetadata.getName());
-            } catch (IllegalArgumentException | IllegalStateException e) {
-                throw new AssertionError(UNABLE_TO_READ_PROPERTY.formatted(propertyMetadata.getName(),
-                    ExceptionHelper.extractCauseMessageFromThrowable(e)), e);
-            }
+    }
+
+    @Override
+    public Object readProperty(final Object target, final PropertyMetadata propertyMetadata) {
+        assertNotNull(target, TARGET_MUST_NOT_BE_NULL);
+        assertNotNull(propertyMetadata, PROPERTY_METADATA_MUST_NOT_BE_NULL);
+        try {
+            return PropertyUtil.readProperty(target, propertyMetadata.getName());
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw new AssertionError(UNABLE_TO_READ_PROPERTY.formatted(propertyMetadata.getName(),
+                ExceptionHelper.extractCauseMessageFromThrowable(e)), e);
         }
-    },
+    }
+},
     /**
      * In some cases the builder supports multiple ways to fill {@link Collection}
      * based elements, e.g. there is a field with the structure

--- a/src/main/java/de/cuioss/test/valueobjects/property/util/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/property/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/AnnotationHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/AnnotationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/BuilderPropertyHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/BuilderPropertyHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/GeneratorAnnotationHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/GeneratorAnnotationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/GeneratorRegistry.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/GeneratorRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/IdentityResourceBundle.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/IdentityResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/ObjectContractHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/ObjectContractHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/PropertyHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/PropertyHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/ReflectionHelper.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/ReflectionHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/StringCaseShuffler.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/StringCaseShuffler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/WildcardDecoratorGenerator.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/WildcardDecoratorGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/de/cuioss/test/valueobjects/util/package-info.java
+++ b/src/main/java/de/cuioss/test/valueobjects/util/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/BeanPropertyContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/BeanPropertyContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/BuilderContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/BuilderContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/ContractRegistryTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/ContractRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/CopyConstructorContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/EqualsAndHashcodeContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/MockTestContract.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/MockTestContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/ObjectCreatorContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/ObjectCreatorContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/ReflectionUtilTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/ReflectionUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/SerializableContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/SerializableContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/ToStringContractImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/ToStringContractImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/support/MapperAttributesAssertsTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/support/MapperAttributesAssertsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/contract/support/MappingAssertStrategyTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/contract/support/MappingAssertStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/TypedGeneratorRegistryTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/TypedGeneratorRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/DynamicTypedGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/DynamicTypedGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolverTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/GeneratorResolverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ArraysGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ArraysGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/CollectionTypeGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/CollectionTypeGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/ConstructorBasedGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DefaultInvocationHandlerTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DefaultInvocationHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Proxy;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class DefaultInvocationHandlerTest {
 
@@ -33,7 +29,7 @@ class DefaultInvocationHandlerTest {
 
     private static Sample newProxy(final DefaultInvocationHandler handler) {
         return (Sample) Proxy.newProxyInstance(DefaultInvocationHandlerTest.class.getClassLoader(),
-            new Class<?>[] { Sample.class }, handler);
+            new Class<?>[]{Sample.class}, handler);
     }
 
     @Test
@@ -57,12 +53,12 @@ class DefaultInvocationHandlerTest {
         final var proxy = newProxy(handler);
 
         // reflexive
-        assertTrue(proxy.equals(proxy));
+        assertEquals(proxy, proxy);
         // null-safe
         assertFalse(proxy.equals(null));
         // two proxies backed by the same handler and interfaces are equal
-        assertTrue(proxy.equals(newProxy(handler)));
+        assertEquals(proxy, newProxy(handler));
         // proxies backed by different handlers are not equal
-        assertFalse(proxy.equals(newProxy(new DefaultInvocationHandler())));
+        assertNotEquals(proxy, newProxy(new DefaultInvocationHandler()));
     }
 }

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/DynamicProxyGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/EmptyMapGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/EmptyMapGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/dynamic/impl/InterfaceProxyGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/generator/impl/DummyGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/generator/impl/DummyGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/StrangeValueObjectTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/StrangeValueObjectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestBeanTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestBuilderTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestConstructorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestCopyConstructorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestCopyConstructorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestFactoryTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestInlineInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/ValueObjectTestInlineInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldHandleObjectContractsTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/contracts/ShouldHandleObjectContractsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/extension/GeneratorControllerWithRegistryTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/extension/GeneratorControllerWithRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/extension/GeneratorControllerWithoutRegistryTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/extension/GeneratorControllerWithoutRegistryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/BeanWithMultipleConstructorAnnotation.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/BeanWithMultipleConstructorAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/OneRequiredFieldCopyConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/OneRequiredFieldCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package de.cuioss.test.valueobjects.junit5.testbeans;
 
 import de.cuioss.test.generator.Generators;
 import de.cuioss.test.valueobjects.api.TestContract;
-import de.cuioss.test.valueobjects.contract.MockTestContract;
 import de.cuioss.test.valueobjects.api.contracts.VerifyCopyConstructor;
+import de.cuioss.test.valueobjects.contract.MockTestContract;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.test.valueobjects.objects.impl.ConstructorBasedInstantiator;
 import de.cuioss.test.valueobjects.property.PropertyMetadata;

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/StrangeInterface.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/StrangeInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/StrangeObject.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/StrangeObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/TwoFactoryBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/TwoFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/UnknownObject.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/UnknownObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/mapper/SimpleMapper.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/mapper/SimpleMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/mapper/SimpleSourceBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/mapper/SimpleSourceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/mapper/SimpleTargetBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/junit5/testbeans/mapper/SimpleTargetBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperEntryDtoToComplexBeanTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperEntryDtoToComplexBeanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import de.cuioss.test.valueobjects.api.VerifyMapperConfiguration;
 import de.cuioss.test.valueobjects.api.property.PropertyConfig;
 import de.cuioss.test.valueobjects.api.property.PropertyReflectionConfig;
 import de.cuioss.test.valueobjects.generator.TypedGeneratorRegistry;
-import de.cuioss.test.valueobjects.testbeans.ComplexBean;
 import de.cuioss.test.valueobjects.mapper.support.EntryDto;
 import de.cuioss.test.valueobjects.mapper.support.EntryDtoToComplexBeanMapper;
 import de.cuioss.test.valueobjects.mapper.support.MapEntryGenerator;
@@ -28,6 +27,7 @@ import de.cuioss.test.valueobjects.objects.ParameterizedInstantiator;
 import de.cuioss.test.valueobjects.objects.RuntimeProperties;
 import de.cuioss.test.valueobjects.objects.impl.ConstructorBasedInstantiator;
 import de.cuioss.test.valueobjects.property.util.CollectionType;
+import de.cuioss.test.valueobjects.testbeans.ComplexBean;
 import de.cuioss.test.valueobjects.util.GeneratorAnnotationHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperInvalidConfigTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperInvalidConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestErrorCollectionMapperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestErrorCollectionMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestErrorMapperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestErrorMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestExceptionMapperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestExceptionMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/BaseMapperTestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,7 @@ import de.cuioss.test.valueobjects.testbeans.mapper.SimpleSourceBean;
 import de.cuioss.test.valueobjects.testbeans.mapper.SimpleTargetBean;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 @VerifyMapperConfiguration(equals = {"firstname:nameFirst", "lastname:nameLast", "attributeList:listOfAttributes"})
 class BaseMapperTestTest extends MapperTest<SimpleMapper, SimpleSourceBean, SimpleTargetBean> {

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/support/ComplexBeanToEntryDtoMapper.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/support/ComplexBeanToEntryDtoMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/support/EntryDto.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/support/EntryDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/support/EntryDtoToComplexBeanMapper.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/support/EntryDtoToComplexBeanMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/mapper/support/MapEntryGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/mapper/support/MapEntryGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/RuntimePropertiesTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/RuntimePropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/AbstractInlineInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/AbstractInlineInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/BeanInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/BeanInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/BuilderConstructorBasedInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/BuilderConstructorBasedInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/BuilderFactoryBasedInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/BuilderFactoryBasedInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/BuilderParameterizedInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/BuilderParameterizedInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/CallbackAwareInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/CallbackAwareInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/ConstructorBasedInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/ConstructorBasedInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/DefaultInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/DefaultInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/ExceptionHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/ExceptionHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/FactoryBasedInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/FactoryBasedInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/InjectedBeanInstantiatorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/InjectedBeanInstantiatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/objects/impl/MockConfigurationCallbackHandler.java
+++ b/src/test/java/de/cuioss/test/valueobjects/objects/impl/MockConfigurationCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/PropertySupportTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/PropertySupportTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/generator/JavaTypesGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/generator/JavaTypesGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/impl/BuilderMetadataTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/impl/BuilderMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/impl/PropertyMetadataImplTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/impl/PropertyMetadataImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/util/CollectionAssertsTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/util/CollectionAssertsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/util/CollectionTypeTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/util/CollectionTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/property/util/PropertyAccessStrategyTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/property/util/PropertyAccessStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/ComplexBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/ComplexBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassComplexSample.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassComplexSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassExcludeName.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassExcludeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassExcludeNameAndDefaultValue.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassExcludeNameAndDefaultValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassInvalidExclude.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassInvalidExclude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassOf.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassSimple.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanPropertyTestClassSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanWithDefensiveArrayCopy.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanWithDefensiveArrayCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanWithStringArray.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/beanproperty/BeanWithStringArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BadBuilderAlwaysFails.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BadBuilderAlwaysFails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BadBuilderFailsOnAttributeRead.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BadBuilderFailsOnAttributeRead.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BadBuilderFailsOnAttributeSet.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BadBuilderFailsOnAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderContractTestConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderContractTestConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderContractTestMinimal.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderContractTestMinimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderContractTestMinimalFactory.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderContractTestMinimalFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderMinimalTestClassComplexSample.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderMinimalTestClassComplexSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderMinimalTestClassSimple.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderMinimalTestClassSimple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderPropertyConfigMinimal.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderPropertyConfigMinimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderPropertyConfigMultiple.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderPropertyConfigMultiple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderWithCollections.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderWithCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderWithRequiredAttribute.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/BuilderWithRequiredAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/InheritedBuilderPropertyConfigMultiple.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/InheritedBuilderPropertyConfigMultiple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/InheritedBuilderPropertyWithAdditionalConfig.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/InheritedBuilderPropertyWithAdditionalConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/LombokBasedBuilder.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/builder/LombokBasedBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithAllRequriedConstructorAnnotation.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithAllRequriedConstructorAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithMultipleArgumentConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithMultipleArgumentConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithMultipleConstructorAnnotation.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithMultipleConstructorAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithMultiplePublicConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithMultiplePublicConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithOneConstructorAnnotation.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithOneConstructorAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithSingleArgumentConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/BeanWithSingleArgumentConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/SimpleConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/constructor/SimpleConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/BadCopyConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/BadCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/BadDeepCopyCopyConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/BadDeepCopyCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/DeepCopyCopyConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/DeepCopyCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/InterfaceCopyConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/InterfaceCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/MockWithReadOnly.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/MockWithReadOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/OneRequiredFieldCopyConstructor.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/copyconstructor/OneRequiredFieldCopyConstructor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/factory/BadFactoryBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/factory/BadFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/factory/OneFactoryBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/factory/OneFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/factory/TwoFactoryBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/factory/TwoFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/ClassWithMixedGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/ClassWithMixedGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/ClassWithOneGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/ClassWithOneGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/ClassWithTwoGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/ClassWithTwoGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/GeneratorHintMultipleAnnotations.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/GeneratorHintMultipleAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/GeneratorHintSingleAnnotation.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/generator/GeneratorHintSingleAnnotation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/ComplexSourceBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/ComplexSourceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleErrorMapper.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleErrorMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleErrorMapperWrongField.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleErrorMapperWrongField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleExceptionMapper.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleExceptionMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleMapper.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleSourceBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleSourceBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleTargetBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/mapper/SimpleTargetBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsForeign.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsForeign.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsNull.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanEqualsNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanWithInvalidEquals.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanWithInvalidEquals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanWithInvalidHashCode.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/BadObjectBeanWithInvalidHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/EqualsAndHashcodeBasicOnly.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/EqualsAndHashcodeBasicOnly.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/EqualsAndHashcodeTwoArgumentBean.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/EqualsAndHashcodeTwoArgumentBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/EqualsAndHashcodeWithExlude.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/objectcontract/EqualsAndHashcodeWithExlude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithFluentSetter.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithFluentSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithNestedGenerics.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithNestedGenerics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithNestedGenericsButFiltered.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithNestedGenericsButFiltered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithPrimitiveByteArray.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithPrimitiveByteArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithRawCollection.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithRawCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithReadWriteProperties.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/BeanWithReadWriteProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyConfigMinimal.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyConfigMinimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyConfigMultiple.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyConfigMultiple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyConfigPropertyClassAndGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyConfigPropertyClassAndGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyReflectionShouldNotSkip.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyReflectionShouldNotSkip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyReflectionShouldSkip.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/property/PropertyReflectionShouldSkip.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/GenericTypeWithLowerBoundType.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/GenericTypeWithLowerBoundType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/ReflectionPostProcessComplex.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/ReflectionPostProcessComplex.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/ReflectionPostProcessMinimal.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/ReflectionPostProcessMinimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/StringTypedGenericType.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/reflection/StringTypedGenericType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationBasicOnlyFalseContract.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationBasicOnlyFalseContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationBasicOnlyTrueContract.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationBasicOnlyTrueContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationEqualsFalseContract.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationEqualsFalseContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationEqualsTrueContract.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationEqualsTrueContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationExclude.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationExclude.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationOf.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationOf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationReadFailure.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationReadFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationWriteFailure.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/serializable/SerializationWriteFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/testgenerator/PropertyMetadataGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/testgenerator/PropertyMetadataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/testgenerator/PropertyMetadataTestDataGenerator.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/testgenerator/PropertyMetadataTestDataGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/tostring/ToStringAnnotatedUseMinimalFalse.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/tostring/ToStringAnnotatedUseMinimalFalse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/tostring/ToStringAnnotatedUseMinimalTrue.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/tostring/ToStringAnnotatedUseMinimalTrue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithMixedVetoes.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithMixedVetoes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithOneOptIn.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithOneOptIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithOneVeto.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithOneVeto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithTwoOptIns.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithTwoOptIns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithTwoVetoes.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/ClassWithTwoVetoes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/InheritedVeto.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/InheritedVeto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/InheritedVetoWithAdditionalVeto.java
+++ b/src/test/java/de/cuioss/test/valueobjects/testbeans/veto/InheritedVetoWithAdditionalVeto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/AnnotationHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/AnnotationHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/BuilderPropertyHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/BuilderPropertyHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/DeepCopyTestHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/GeneratorAnnotationHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/GeneratorAnnotationHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/IdentityResourceBundleTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/IdentityResourceBundleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/ObjectContractHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/ObjectContractHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/PropertyHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/PropertyHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/ReflectionHelperTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/ReflectionHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/StringCaseShufflerTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/StringCaseShufflerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/de/cuioss/test/valueobjects/util/WildcardDecoratorGeneratorTest.java
+++ b/src/test/java/de/cuioss/test/valueobjects/util/WildcardDecoratorGeneratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ * Copyright © 2023-present CUI-OpenSource-Software (info@cuioss.de)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,7 @@ import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class WildcardDecoratorGeneratorTest {
 


### PR DESCRIPTION
## Why

`<inceptionYear>` is an **inherited** POM element, and the mycila `license-maven-plugin` binds the copyright `${year}` to `project.inceptionYear` — **not** to the current year:

```
ldc           "year"
getfield      project
invokevirtual MavenProject.getInceptionYear()
```

`cui-parent-pom` held the only declaration in the hierarchy (`2022`), so this project reported 2022 and **every `-Ppre-commit` run restamped every source header**. Declaring the real year stops that.

## The year

`2023` — from this repository's own first commit, not the parent and not GitHub's `created_at`.

## What is in this PR

Two things, and it is worth being precise about the second:

1. `pom.xml` gains `<inceptionYear>2023</inceptionYear>`, and the license plugin rewrites every source header to `© 2023-present`. **This is the change being made.**
2. **Pre-existing gate drift**, ~183 non-header lines. `-Ppre-commit` also runs OpenRewrite, which reorders imports, reformats, and adds build-plugin blocks. Confirmed pre-existing: running the gate on **unmodified `main`**, with no `inceptionYear` at all, produces the same kind of changes.

It cannot be split out. The gate re-applies it on the next run, so a header-only tree would not be gate-stable — and gate-stability is precisely the property this PR exists to restore.

## Verification

The gate was run **twice**. The second run rewrote nothing and left a tree identical to the first. That idempotence is what was broken, so it is the thing checked — not merely that the build passes.

Confirmed afterwards that every `.java` header in the tree reads `© 2023-present`, with no stragglers on other years.