### PR TITLE
docs(release-skill): collapse notes by library identity and derive versions from project.yml

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -50,17 +50,22 @@ before the wider org picks the change up.
 
 ### Step 1 — Determine the version number
 
-Read the `release` block in `.github/project.yml`:
-- `release.current-version` (currently `2.1.3`) — the **last released** version.
-- `release.next-version` (currently `2.1-SNAPSHOT`) — what `pom.xml` carries between releases.
+`.github/project.yml` is the single source of truth for both versions — read it, never
+assume:
 
-**Default rule (patch line):** `current-version` is `2.1.3` and the pom floats on
-`2.1-SNAPSHOT`, so releases run along the patch line: the release version is `current-version`
-with the **patch segment incremented** (`2.1.3` → **`2.1.4`**), and
-`next-version` is left **unchanged**.
+```bash
+grep -E 'current-version|next-version' .github/project.yml
+```
 
-**Starting a new minor line** (`2.1` → the next minor) also moves `next-version`.
-That is a deliberate decision — **ask the user** (AskUserQuestion) before assuming it.
+- `release.current-version` — the **last released** version.
+- `release.next-version` — what `pom.xml` carries between releases.
+
+**Default rule (patch line):** `current-version` sits on the patch line while the pom floats
+on the `X.Y-SNAPSHOT` minor floor, so the release version is `current-version` with the
+**patch segment incremented**, and `next-version` is left **unchanged**.
+
+**Starting a new minor line** also moves `next-version`. That is a deliberate decision —
+**ask the user** (AskUserQuestion) before assuming it.
 
 ### Step 2 — Check for open PRs
 
@@ -85,13 +90,13 @@ The Maven CI workflow only triggers on `main, "feature/*", "fix/*", "chore/*", "
 check and blocks the merge:
 
 ```bash
-git checkout -b chore/release_2.1.4
+git checkout -b chore/release_<version>
 ```
 
 ### Step 5 — Update `.github/project.yml`
 
-- `current-version:` → `2.1.4`
-- `next-version:` → **unchanged** (`2.1-SNAPSHOT`); only bump it when starting a new minor line
+- `current-version:` → the version determined in Step 1
+- `next-version:` → **unchanged**; only bump it when starting a new minor line
 
 Leave everything else untouched. The README badges are dynamic endpoints — there is **no**
 per-release badge to hand-edit.
@@ -197,14 +202,52 @@ gh release edit <version> --repo cuioss/cui-test-value-objects --notes-file .pla
    adapted to this project's domain; omit empty sections.
 3. **Dependency Updates** — `### Java` for libraries, `### Infra` for build plugins,
    `cuioss-organization` workflow bumps and parent-POM updates.
-4. **Collapse version chains** — `A → B → C` becomes a single entry spanning `A → C`.
-5. **Drop OpenRewrite bumps** — `rewrite-maven-plugin`, `rewrite-migrate-java`,
+4. **Collapse by library identity — one line per library, spanning the full range.**
+   The unit of collapsing is the *library*, not the PR title. Merge into a single line
+   whenever the PRs concern the same library, in all three shapes that occur:
+   - **Version chains** — several bumps of one artifact (`A → B → C`) collapse to one line
+     spanning `A → C`, carrying the latest PR's author.
+   - **The same library in several places** — one library bumped in more than one module or
+     directory is **one** line naming them all, not one line each. Those titles differ only
+     by that suffix, so do not wait for identical titles before merging.
+   - **One upstream release landing as several coordinates** — when a single upstream bump
+     arrives as separate PRs against different coordinates (e.g. a version property *and*
+     a BOM or parent), that is **one** bump: one line naming the coordinates in parentheses.
+
+   Carry every merged PR's URL onto the surviving line, comma-separated.
+5. **Recover versions the title omits.** Dependabot truncates a title to
+   `bump <lib> in /<dir>`, with no versions, when several dependencies must move together.
+   Never publish a dependency line without a version range: read the PR body, which states
+   ``Updates `<lib>` from X to Y``, and use those versions when computing the range:
+
+   ```bash
+   gh pr view <n> --repo cuioss/cui-test-value-objects --json body --jq .body | head -6
+   ```
+6. **Drop OpenRewrite bumps** — `rewrite-maven-plugin`, `rewrite-migrate-java`,
    `rewrite-testing-frameworks` and friends.
-6. **Drop internal tooling churn** — `marshal.json`/plan-marshall config, dev-skill changes,
+7. **Drop internal tooling churn** — `marshal.json`/plan-marshall config, dev-skill changes,
    and the mechanical version-bump PR itself.
-7. Keep each surviving PR line verbatim (`* <title> by @author in <url>`); merge duplicates
-   onto one line with both URLs.
-8. Keep the trailing `**Full Changelog**: ...compare/<prev>...<version>` line.
+8. **Preserve each kept PR line** in its original
+   `* <title> by @author in <url>` shape. Rules 4 and 5 **override** verbatimness where
+   they conflict: rewrite the title's version range to span the collapsed chain, and name
+   the several modules or coordinates on the surviving line.
+9. Keep the trailing `**Full Changelog**: ...compare/<prev>...<version>` line.
+
+#### Verify before publishing (mandatory)
+
+These rules are easy to under-apply: a duplicate survives whenever two PRs touch the same
+library under differing titles. After building the notes file and **before**
+`gh release edit`, assert that every library appears exactly once:
+
+```bash
+grep -oE '(bump|update) [^ ]+ (from|in)' .plan/temp/release-<version>.md \
+  | sort | uniq -c | sort -rn | head
+```
+
+Every count must be `1`. Any count `>1` is an unmerged duplicate — collapse it per rule
+4 and re-run. Also confirm that no dependency line is missing a version range
+(rule 5).
+
 
 ### Step 13 — Done
 


### PR DESCRIPTION
Aligns this repo's release skill with the fixes found while cutting a release in
nifi-extensions, where four dependency entries shipped duplicated in the notes.

## Release-note grouping

The collapse rule keyed on **PR-title equality**, so titles differing only by a
directory or coordinate suffix matched nothing and both lines survived.

- **Collapse by library identity**, spelling out the three shapes that occur: version
  chains, the same library bumped in several modules/directories, and one upstream
  release landing as several coordinates (e.g. a version property *and* a BOM/parent).
- **Recover versions the title omits** — Dependabot truncates a title to
  `bump <lib> in /<dir>` when several deps must move together; the versions are then
  only in the PR body. No dependency line may ship without a version range.
- **Resolved a contradiction**: the old rules required both rewriting the version range
  when collapsing and preserving each line verbatim. The collapse rules now explicitly win.
- **Added a mandatory duplicate check** before `gh release edit`: every library must
  appear exactly once. This catches the above mechanically instead of by careful reading.

## Versions derived from `.github/project.yml`

The skill restated `current-version` / `next-version` inline and built its examples
around that hardcoded pair, so every release made the skill stale. Both numbers are now
read from `.github/project.yml`, and the branch-name and `project.yml`-edit examples use
placeholders. The repo's own versioning policy is preserved, expressed symbolically.

Documentation-only change under `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDdBo9BsuMyifN5g6551v7